### PR TITLE
修正 sn_list內 "@前進球場 " 尾端為 '空白' 時，導致路徑名稱錯誤而引發崩潰

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -500,6 +500,7 @@ def read_sn_list():
                         rename = re.findall(r'<.*>', i)[0][1:-1]
                 else:  # 没有指定下载模式则使用默认设定
                     sn_dict[int(a[0])] = {'mode': settings['default_download_mode']}
+                bangumi_tag = re.sub(r" $","",bangumi_tag)
                 sn_dict[int(a[0])]['tag'] = bangumi_tag
                 sn_dict[int(a[0])]['rename'] = rename
         return sn_dict


### PR DESCRIPTION

如題
![Imgur](https://imgur.com/BbDAsDk.png)
遇到 sn_list.txt 為上圖(@名稱後含有空白)時會引發下圖左方錯誤，下又則是修正後的
![修正前後](https://imgur.com/UydwO5G.png)

----
感謝作者大大開源該專案，十分好用 m(_ _)m
