### PR TITLE
增加ffmpeg轉檔時增加日文語言標籤

### DIFF
--- a/Anime.py
+++ b/Anime.py
@@ -538,6 +538,9 @@ class Anime():
             # 此功能可以更快的在线播放视频
             ffmpeg_cmd[7:7] = iter(['-movflags', 'faststart'])
 
+        if self._settings['audio_language_jpn']:
+            ffmpeg_cmd[7:7] = iter(['-metadata:s:a:0', 'language=jpn'])
+
         # 执行 ffmpeg
         run_ffmpeg = subprocess.Popen(ffmpeg_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         run_ffmpeg.communicate()

--- a/Config.py
+++ b/Config.py
@@ -110,6 +110,7 @@ def __init_settings():
                     }
                 },
                 'faststart_movflags': False,
+                'audio_language_jpn': False,
                 'check_latest_version': True,  # 是否检查新版本
                 'read_sn_list_when_checking_update': True,
                 'read_config_when_checking_update': True,

--- a/config-sample.json
+++ b/config-sample.json
@@ -48,6 +48,7 @@
         }
     },
     "faststart_movflags": false,
+    "audio_language_jpn": false,
     "check_latest_version": true,
     "read_sn_list_when_checking_update": true,
     "read_config_when_checking_update": true,


### PR DESCRIPTION
增加這項是為了使用Plex或Emby管理影片時，
不要讓語言顯示為Unknown
而是顯示為日本語(Japanese)

修改前：
![image](https://user-images.githubusercontent.com/17351171/78460551-5518ae00-76f4-11ea-8aee-1d14d5629c6b.png)
修改後：
![image](https://user-images.githubusercontent.com/17351171/78460579-885b3d00-76f4-11ea-999d-594fbd7db284.png)
