### PR TITLE
add swapHistorySnList.py

### DIFF
--- a/swapHistorySnList.py
+++ b/swapHistorySnList.py
@@ -1,0 +1,24 @@
+import os
+import sqlite3
+
+FILE_CURRENT = "sn_list.txt"
+FILE_TEMP = "sn_list-temp.txt"
+FILE_DB = "aniGamer.db"
+
+# Backup sn_list
+if os.path.isfile(FILE_TEMP):
+    print("Restore sn_list")
+    os.remove(FILE_CURRENT)
+    os.rename(FILE_TEMP, FILE_CURRENT)
+    exit()
+elif os.path.isfile(FILE_CURRENT):
+    print("Backup sn_list")
+    os.rename(FILE_CURRENT, FILE_TEMP)
+
+print("Fetch history list")
+conn = sqlite3.connect(FILE_DB)
+c = conn.cursor()
+history_list = c.execute("SELECT sn, anime_name FROM anime GROUP BY anime_name;")
+with open(FILE_CURRENT, "w", encoding='UTF-8') as file:
+    for row in history_list:
+        file.write(str(row[0])+" all # "+row[1]+"\n")


### PR DESCRIPTION
### Change:
&nbsp;&nbsp;add swapHistorySnList.py  
### Scenario:  
&nbsp;&nbsp;After the episodes download successful, I will remove the specific line in sn_list.txt to prevent duplicate checking, since it will take a lot of time when Internet bandwidth is full. However, I also wish that I can easily check if a new episode was released in my history list. Here is the solution.  
### Usage:  
&nbsp;&nbsp;By running the swapHistorySnList.py, it will back up the sn_list.txt to sn_list-temp.txt and generate a new sn_list.txt by check the aniGamer.db to generate a sn_list.txt with history. In this way, we can easily start the aniGamerPlus to check the series downloaded in the past.  
&nbsp;&nbsp;To restore the sn_list.txt, just run swapHistorySnList.py for another time, and sn_list.txt will be restored.  