### PR TITLE
修正當執行路徑並非專案根目錄時，會抓不到 DanmuTemplate.ass 的問題

### DIFF
--- a/Danmu.py
+++ b/Danmu.py
@@ -2,6 +2,7 @@
 import requests
 import json
 import random
+import os
 from ColorPrint import err_print
 
 
@@ -30,7 +31,8 @@ class Danmu():
             return
 
         output = open(self._full_filename, 'w', encoding='utf8')
-        with open('DanmuTemplate.ass', 'r', encoding='utf8') as temp:
+        danmu_template_file = os.path.join(os.path.dirname(__file__), 'DanmuTemplate.ass')
+        with open(danmu_template_file, 'r', encoding='utf8') as temp:
             for line in temp.readlines():
                 output.write(line)
 


### PR DESCRIPTION
例如使用 /opt/aniGamerPlus/aniGamerPlus.py 執行主程式，原本的寫法會跑到當前工作目錄去抓檔案
對於利用 script 或是設定成 service 啟動的使用者會有影響