### PR TITLE
新增彈幕過濾功能

### DIFF
--- a/Anime.py
+++ b/Anime.py
@@ -883,7 +883,7 @@ class Anime():
         if self._danmu:
             full_filename = os.path.join(self._bangumi_dir, self.__get_filename(resolution)).replace('.' + self._settings['video_filename_extension'], '.ass')
             d = Danmu(self._sn, full_filename)
-            d.download()
+            d.download(self._settings['danmu_ban_words'])
 
         # 推送 CQ 通知
         if self._settings['coolq_notify']:

--- a/Config.py
+++ b/Config.py
@@ -130,6 +130,7 @@ def __init_settings():
                 'audio_language': False,
                 'use_mobile_api': False,
                 'danmu': False,
+                'danmu_ban_words': [],
                 'check_latest_version': True,  # 是否检查新版本
                 'read_sn_list_when_checking_update': True,
                 'read_config_when_checking_update': True,
@@ -297,6 +298,9 @@ def __update_settings(old_settings):  # 升级配置文件
         # 支持下载弹幕
         # https://github.com/miyouzi/aniGamerPlus/pull/66
         new_settings['danmu'] = False
+
+    if 'danmu_ban_words' not in new_settings.keys():
+        new_settings['danmu_ban_words'] = []
 
     if 'use_mobile_api' not in new_settings.keys():
         # v21.0 新增使用APP API #69

--- a/Danmu.py
+++ b/Danmu.py
@@ -2,6 +2,7 @@
 import requests
 import json
 import random
+import re
 import os
 from ColorPrint import err_print
 
@@ -17,7 +18,10 @@ class Danmu():
         b = RGBcolor[4:6]
         return f"{b}{g}{r}"
 
-    def download(self):
+    def find_ban_word(self, text, ban_word_re):
+        return ban_word_re.search(text) != None
+
+    def download(self, ban_words):
         h = {
             'Content-Type':
             'application/x-www-form-urlencoded;charset=utf-8',
@@ -47,8 +51,13 @@ class Danmu():
         roll_channel = list()
         roll_time = list()
 
+        ban_word_re = re.compile("|".join(ban_words), re.IGNORECASE)
+
         for danmu in j:
-            BGRcolor = self.get_BGRcolor(danmu['color'][1:])
+            text = danmu['text']
+            if self.find_ban_word(text, ban_word_re):
+                err_print(self._sn, f'跳過彈幕 [{text}]', self._full_filename, display=False)
+                continue
 
             output.write('Dialogue: ')
             output.write('0,')
@@ -59,6 +68,7 @@ class Danmu():
             h, m = divmod(m, 60)
             output.write(f'{h:d}:{m:02d}:{s:02d}.{hundred_ms:d}0,')
 
+            BGRcolor = self.get_BGRcolor(danmu['color'][1:])
             if danmu['position'] == 0:  # Roll danmu
                 height = 0
                 end_time = 0
@@ -66,13 +76,14 @@ class Danmu():
                     if roll_channel[i] <= danmu['time']:
                         height = i * 54 + 27
                         roll_channel[i] = danmu['time'] + \
-                            (len(danmu['text']) * roll_time[i]) / 8 + 1
+                            (len(text) * roll_time[i]) / 8 + 1
                         end_time = start_time + roll_time[i]
                         break
                 if height == 0:
                     roll_channel.append(0)
                     roll_time.append(random.randint(10, 14))
-                    roll_channel[-1] = danmu['time'] + (len(danmu['text']) * roll_time[-1]) / 8 + 1
+                    roll_channel[-1] = danmu['time'] + \
+                        (len(text) * roll_time[-1]) / 8 + 1
                     height = len(roll_channel) * 54 - 27
                     end_time = start_time + roll_time[-1]
 
@@ -97,7 +108,7 @@ class Danmu():
                 output.write(
                     'Bottom,,0,0,0,,{\\1c&H4C' + BGRcolor + '}')
 
-            output.write(danmu['text'])
+            output.write(text)
             output.write('\n')
 
         err_print(self._sn, '彈幕下載完成', self._full_filename, status=2)

--- a/Danmu.py
+++ b/Danmu.py
@@ -8,9 +8,10 @@ from ColorPrint import err_print
 
 
 class Danmu():
-    def __init__(self, sn, full_filename):
+    def __init__(self, sn, full_filename, cookies):
         self._sn = sn
         self._full_filename = full_filename
+        self._cookies = cookies
 
     def get_BGRcolor(self, RGBcolor):
         r = RGBcolor[0:2]
@@ -39,6 +40,28 @@ class Danmu():
         if r.status_code != 200:
             err_print(self._sn, '彈幕下載失敗', 'status_code=' + str(r.status_code), status=1)
             return
+
+        h = {
+            'accept':
+            'application/json',
+            'origin':
+            'https://ani.gamer.com.tw',
+            'authority':
+            'ani.gamer.com.tw',
+            'user-agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36',
+        }
+        ban_words_response = requests.get(
+            'https://ani.gamer.com.tw/ajax/keywordGet.php', headers=h, cookies=self._cookies)
+
+        if ban_words_response.status_code != 200:
+            err_print(self._sn, '取得線上過濾彈幕失敗', 'status_code=' +
+                      str(r.status_code), status=1)
+        else:
+            online_ban_words = json.loads(ban_words_response.text)
+            for online_ban_word in online_ban_words:
+                err_print(self._sn, '取得線上過濾彈幕', detail=online_ban_word['keyword'], status=0, display=False)
+                ban_words.append(online_ban_word['keyword'])
 
         output = open(self._full_filename, 'w', encoding='utf8')
         danmu_template_file = os.path.join(os.path.dirname(__file__), 'DanmuTemplate.ass')

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ docker run -td --name anigamerplus \
  - v16 支援向酷Q推送下載完成訊息
  - v16 支援将影片 metadata 前置, 此功能會在綫觀看时更快播放
  - v20 上綫Web控制面板
- - v20.2 支援命令行下載時同時下載彈幕(beta)
+ - v20.2 支援命令行下載時同時下載彈幕
 
 ## 任務列表
  - [x] 下載使用代理
@@ -194,6 +194,8 @@ docker run -td --name anigamerplus \
     "faststart_movflags": false,  # 是否將影片 metadata 前置, 啓用此功能時在綫觀看會更快播放, 僅在 video_filename_extension 為 mp4 時有效
     "audio_language": false,  # 是否添加音軌標簽
     "use_mobile_api": false,  # 使用移動端API進行影片解析
+    "danmu": false, # 是否下載彈幕
+    "danmu_ban_words": [], # 過濾彈幕關鍵字(支援python的正規表示式、英文不區分大小寫)
     "check_latest_version": true,  # 是否檢查更新
     "read_sn_list_when_checking_update": true,  # 是否在檢查更新時讀取sn_list.txt, 開啓後對sn_list.txt的更改將會在下次檢查更新時生效而不用重啓程序
     "read_config_when_checking_update": true,  # 是否在檢查更新時讀取配置文件, 開啓後對配置文件的更改將會在下次檢查時更新生效而不用重啓程序
@@ -419,7 +421,7 @@ optional arguments:
   --information_only, -i
                         僅查詢資訊
   --user_command, -u    所有下載完成后執行用戶命令
-  --danmu, -d           以 .ass 下載彈幕(beta)
+  --danmu, -d           以 `.ass` 下載彈幕
 ```
 
  - **-s** 接要下載視頻的sn碼,不可空
@@ -456,7 +458,7 @@ optional arguments:
 
  - **-u** 所有任務完成后執行使用者命令 (配置在```config.json```的```user_command```中),  用於實現下載完成后關機等操作
 
- - **-d** 下載 .ass 彈幕(beta)，推薦使用 XySubFilter 進行字幕渲染
+ - **-d** 下載 `.ass` 彈幕，推薦使用 XySubFilter 進行字幕渲染
 
  - **-e**
     - **在 ```range``` 模式下, 下載此番劇指定劇集, 支援範圍輸入, 支援多個不連續聚集下載, 僅支援整數命名的劇集**

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ docker run -td --name anigamerplus \
 
 若不存在**config.json**, 则程序在运行时将会使用默认配置创建.
 
-```
+```json
 {
     "bangumi_dir": "",  # 下載存放目錄, 動畫將會以番劇為單位分資料夾存放
     "temp_dir": "",  # 臨時目錄位置, v9.0 開始下載中文件將會放在這裏, 完成後再轉移至番劇目錄, 留空默認在程序所在目錄的 temp 資料夾下
@@ -194,8 +194,8 @@ docker run -td --name anigamerplus \
     "faststart_movflags": false,  # 是否將影片 metadata 前置, 啓用此功能時在綫觀看會更快播放, 僅在 video_filename_extension 為 mp4 時有效
     "audio_language": false,  # 是否添加音軌標簽
     "use_mobile_api": false,  # 使用移動端API進行影片解析
-    "danmu": false, # 是否下載彈幕
-    "danmu_ban_words": [], # 過濾彈幕關鍵字(支援python的正規表示式、英文不區分大小寫)
+    "danmu": false, # 是否下載彈幕(已包含動畫瘋內建的關鍵字過濾)
+    "danmu_ban_words": [], # 額外過濾彈幕關鍵字(支援python的正規表示式、英文不區分大小寫)
     "check_latest_version": true,  # 是否檢查更新
     "read_sn_list_when_checking_update": true,  # 是否在檢查更新時讀取sn_list.txt, 開啓後對sn_list.txt的更改將會在下次檢查更新時生效而不用重啓程序
     "read_config_when_checking_update": true,  # 是否在檢查更新時讀取配置文件, 開啓後對配置文件的更改將會在下次檢查時更新生效而不用重啓程序

--- a/aniGamerPlus.py
+++ b/aniGamerPlus.py
@@ -391,7 +391,7 @@ def __get_info_only(sn):
 
     if danmu:
         full_filename = os.path.join(download_dir, anime.get_filename()).replace('.' + settings['video_filename_extension'], '.ass')
-        d = Danmu(sn, full_filename)
+        d = Danmu(sn, full_filename, Config.read_cookie())
         d.download(settings['danmu_ban_words'])
 
     thread_limiter.release()
@@ -747,7 +747,7 @@ if __name__ == '__main__':
         parser.add_argument('--no_classify', '-n', action='store_true', help='不建立番劇資料夾')
         parser.add_argument('--user_command', '-u', action='store_true', help='所有下載完成后執行用戶命令')
         parser.add_argument('--information_only', '-i', action='store_true', help='僅查詢資訊，可搭配 -d 更新彈幕')
-        parser.add_argument('--danmu', '-d', action='store_true', help='以 .ass 下載彈幕(beta)')
+        parser.add_argument('--danmu', '-d', action='store_true', help='以 .ass 下載彈幕')
         arg = parser.parse_args()
 
         if (arg.download_mode not in ('list', 'multi', 'sn-list')) and arg.sn is None:

--- a/aniGamerPlus.py
+++ b/aniGamerPlus.py
@@ -392,7 +392,7 @@ def __get_info_only(sn):
     if danmu:
         full_filename = os.path.join(download_dir, anime.get_filename()).replace('.' + settings['video_filename_extension'], '.ass')
         d = Danmu(sn, full_filename)
-        d.download()
+        d.download(settings['danmu_ban_words'])
 
     thread_limiter.release()
 


### PR DESCRIPTION
新增彈幕過濾功能

如題，參考issue #139 

### 改動

1. 於`config.json`中新增: `danmu_ban_words`
   - list, 預設為空
2. 新增彈幕實作: 只要彈幕中包含**任何一個**在`danmu_ban_words`的字，就不會儲存
   - 因為使用regular expression實作，可以寫成`^簽$`，就不會過濾掉`簽到`、`標簽`等字
   - 英文不區分大小寫
   - 跳過的彈幕會寫在log
3. 於`README.md`中新增說明
   - 包含移除彈幕功能的`(beta)`

個人認為此欄位的預設值可為`^簽$`, `^签$`等無意義的文字。

### 其他

- 控制台`Server.py`的部份先不修改
- 建議：`config.json`已經太多設定，需要分類