### PR TITLE
統一程式碼內的用語以及排版

### DIFF
--- a/Anime.py
+++ b/Anime.py
@@ -14,14 +14,13 @@ from ftplib import FTP, FTP_TLS
 import socket
 import threading
 from urllib.parse import quote
-import json
-import requests
+
 
 class TryTooManyTimeError(BaseException):
     pass
 
 
-class Anime():
+class Anime:
     def __init__(self, sn, debug_mode=False, gost_port=34173):
         self._settings = Config.read_settings()
         self._cookies = Config.read_cookie()
@@ -49,7 +48,7 @@ class Anime():
         self._danmu = False
 
         if self._settings['use_mobile_api']:
-            err_print(sn, '解析模式', 'APP解析',display=False)
+            err_print(sn, '解析模式', 'APP解析', display=False)
         else:
             err_print(sn, '解析模式', 'Web解析', display=False)
 

--- a/Anime.py
+++ b/Anime.py
@@ -947,6 +947,17 @@ class Anime:
             if r.status_code != 200:
                 err_print(self._sn, 'discord NOTIFY ERROR', "Exception: Send msg error\nReq: " + req, status=1)
 
+        # plex 自動更新媒體庫
+        if self._settings['plex_refresh']:
+            url = 'https://{plex_url}/library/sections/{plex_section}/refresh?X-Plex-Token={plex_token}'.format(
+                plex_url=self._settings['plex_url'],
+                plex_section=self._settings['plex_section'],
+                plex_token=self._settings['plex_token']
+            )
+            r = requests.get(url)
+            if r.status_code != 200:
+                err_print(self._sn, 'Plex auto Refresh ERROR', status=1)
+
     def upload(self, bangumi_tag='', debug_file=''):
         first_connect = True  # 标记是否是第一次连接, 第一次连接会删除临时缓存目录
         tmp_dir = str(self._sn) + '-uploading-by-aniGamerPlus'

--- a/Anime.py
+++ b/Anime.py
@@ -773,8 +773,8 @@ class Anime:
             else:
                 shutil.move(downloading_file, output_file)  # 此方法在遇到 rclone 掛載時會出錯
 
-                self.local_video_path = output_file  # 記錄儲存路徑，FTP 上傳用
-                self._video_filename = filename  # 記錄檔名，FTP 上傳用
+            self.local_video_path = output_file  # 記錄儲存路徑，FTP 上傳用
+            self._video_filename = filename  # 記錄檔名，FTP 上傳用
             err_print(self._sn, '下載完成', filename, status=2)
         else:
             err_msg_detail = filename + ' ffmpeg_return_code=' + str(
@@ -996,9 +996,9 @@ class Anime:
                         else:
                             detail = self._video_filename + ' 連線FTP時發生錯誤，5 分鐘後重試，最多重試三次：' + str(e)
                             err_print(self._sn, 'FTP 狀態', detail, status=1)
-                        err_counter = err_counter + 1
-                        for i in range(5 * 60):
-                            time.sleep(1)
+                    err_counter = err_counter + 1
+                    for i in range(5 * 60):
+                        time.sleep(1)
                 except BaseException as e:
                     if show_err:
                         detail = self._video_filename + ' 在連線 FTP 時發生無法處理的異常：' + str(e)

--- a/Anime.py
+++ b/Anime.py
@@ -48,9 +48,9 @@ class Anime:
         self._danmu = False
 
         if self._settings['use_mobile_api']:
-            err_print(sn, '解析模式', 'APP解析', display=False)
+            err_print(sn, '解析模式', 'APP 解析', display=False)
         else:
-            err_print(sn, '解析模式', 'Web解析', display=False)
+            err_print(sn, '解析模式', 'Web 解析', display=False)
 
         if debug_mode:
             print('當前為debug模式')
@@ -58,23 +58,23 @@ class Anime:
             if self._settings['use_proxy']:  # 使用代理
                 self.__init_proxy()
             self.__init_header()  # http header
-            self.__get_src()  # 获取网页, 产生 self._src (BeautifulSoup)
-            self.__get_title()  # 提取页面标题
+            self.__get_src()  # 獲取網頁, 產生 self._src (BeautifulSoup)
+            self.__get_title()  # 提取頁面標題
             self.__get_bangumi_name()  # 提取本番名字
-            self.__get_episode()  # 提取剧集码，str
-            # 提取剧集列表，结构 {'episode': sn}，储存到 self._episode_list, sn 为 int, 考慮到 劇場版 sp 等存在, key 為 str
+            self.__get_episode()  # 提取劇集碼，str
+            # 提取劇集列表，結構 {'episode': sn}，儲存到 self._episode_list, sn 為 int, 考慮到 劇場版 sp 等存在, key 為 str
             self.__get_episode_list()
 
     def __init_proxy(self):
         if self._settings['use_gost']:
-            # 需要使用 gost 的情况, 代理到 gost
+            # 需要使用 gost 的情況，代理到 gost
             os.environ['HTTP_PROXY'] = 'http://127.0.0.1:' + self._gost_port
             os.environ['HTTPS_PROXY'] = 'http://127.0.0.1:' + self._gost_port
         else:
-            # 无需 gost 的情况
+            # 無需 gost 的情況
             os.environ['HTTP_PROXY'] = self._settings['proxy']
             os.environ['HTTPS_PROXY'] = self._settings['proxy']
-        os.environ['NO_PROXY'] = "127.0.0.1,localhost"
+        os.environ['NO_PROXY'] = '127.0.0.1,localhost'
 
     def renew(self):
         self.__get_src()
@@ -123,29 +123,29 @@ class Anime:
             try:
                 self._title = self._src['anime']['title']
             except KeyError:
-                err_print(self._sn, 'ERROR: 該 sn 下真的有動畫？', status=1)
+                err_print(self._sn, 'ERROR：該 sn 下真的有動畫？', status=1)
                 self._episode_list = {}
                 sys.exit(1)
         else:
             soup = self._src
             try:
-                self._title = soup.find('div', 'anime_name').h1.string  # 提取标题（含有集数）
+                self._title = soup.find('div', 'anime_name').h1.string  # 提取標題（含有集數）
             except (TypeError, AttributeError):
-                # 该sn下没有动画
-                err_print(self._sn, 'ERROR: 該 sn 下真的有動畫？', status=1)
+                # 該sn下沒有動畫
+                err_print(self._sn, 'ERROR：該 sn 下真的有動畫？', status=1)
                 self._episode_list = {}
                 sys.exit(1)
 
     def __get_bangumi_name(self):
-        self._bangumi_name = self._title.replace('[' + self.get_episode() + ']', '').strip()  # 提取番剧名（去掉集数后缀）
-        self._bangumi_name = re.sub(r'\s+', ' ', self._bangumi_name)  # 去除重复空格
+        self._bangumi_name = self._title.replace('[' + self.get_episode() + ']', '').strip()  # 提取番劇名（去掉集數字尾）
+        self._bangumi_name = re.sub(r'\s+', ' ', self._bangumi_name)  # 去除重複空格
 
-    def __get_episode(self):  # 提取集数
+    def __get_episode(self):  # 提取集數
 
         def get_ep():
-            # 20210719 动画疯的版本位置又瞎蹦跶
+            # 20210719 動畫瘋的版本位置又瞎蹦躂
             # https://github.com/miyouzi/aniGamerPlus/issues/109
-            # 先查看有沒有數字, 如果沒有再查看有沒有中括號, 如果都沒有直接放棄, 把集數填作 1
+            # 先檢視有沒有數字, 如果沒有再檢視有沒有中括號, 如果都沒有直接放棄, 把集數填作 1
             self._episode = re.findall(r'\[\d*\.?\d* *\.?[A-Z,a-z]*(?:電影)?\]', self._title)
             if len(self._episode) > 0:
                 self._episode = str(self._episode[0][1:-1])
@@ -155,22 +155,22 @@ class Anime:
             else:
                 self._episode = "1"
 
-        # 20200320 发现多版本标签后置导致原集数提取方法失效
+        # 20200320 發現多版本標籤後置導致原集數提取方法失效
         # https://github.com/miyouzi/aniGamerPlus/issues/36
-        # self._episode = re.findall(r'\[.+?\]', self._title)  # 非贪婪匹配
-        # self._episode = str(self._episode[-1][1:-1])  # 考虑到 .5 集和 sp、ova 等存在，以str储存
+        # self._episode = re.findall(r'\[.+?\]', self._title)  # 非貪婪匹配
+        # self._episode = str(self._episode[-1][1:-1])  # 考慮到 .5 集和 sp、ova 等存在，以 str 儲存
         if self._settings['use_mobile_api']:
             get_ep()
         else:
             soup = self._src
             try:
-                #  适用于存在剧集列表
+                #  適用於存在劇集列表
                 self._episode = str(soup.find('li', 'playing').a.string)
             except AttributeError:
-                # 如果这个sn就一集, 不存在剧集列表的情况
+                # 如果這個 sn 就一集，不存在劇集列表的情況
                 # https://github.com/miyouzi/aniGamerPlus/issues/36#issuecomment-605065988
-                # self._episode = re.findall(r'\[.+?\]', self._title)  # 非贪婪匹配
-                # self._episode = str(self._episode[0][1:-1])  # 考虑到 .5 集和 sp、ova 等存在，以str储存
+                # self._episode = re.findall(r'\[.+?\]', self._title)  # 非貪婪匹配
+                # self._episode = str(self._episode[0][1:-1])  # 考慮到 .5 集和 sp、ova 等存在，以 str 儲存
                 get_ep()
 
     def __get_episode_list(self):
@@ -180,17 +180,17 @@ class Anime:
                     if _type == '0':
                         self._episode_list[str(_sn['volume'])] = int(_sn["video_sn"])
                     elif _type == '1' or _type == '4':
-                        self._episode_list[self._src["videoTypeList"][int(_type)]["name"]] = int(_sn["video_sn"])
+                        self._episode_list[self._src["videoTypeList"][int(_type)]["name"]] = int(_sn['video_sn'])
                     else:
-                        self._episode_list[f'{self._src["videoTypeList"][int(_type)]["name"]} {_sn["volume"]}'] = int(_sn["video_sn"])
+                        self._episode_list[f'{self._src["videoTypeList"][int(_type)]["name"]} {_sn["volume"]}'] = int(_sn['video_sn'])
         else:
             try:
                 a = self._src.find('section', 'season').find_all('a')
                 p = self._src.find('section', 'season').find_all('p')
                 # https://github.com/miyouzi/aniGamerPlus/issues/9
-                # 样本 https://ani.gamer.com.tw/animeVideo.php?sn=10210
-                # 20190413 动画疯将特别篇分离
-                index_counter = {}  # 记录剧集数字重复次数, 用作列表类型的索引 ('本篇', '特別篇')
+                # 樣本 https://ani.gamer.com.tw/animeVideo.php?sn=10210
+                # 20190413 動畫瘋將特別篇分離
+                index_counter = {}  # 記錄劇集數字重複次數, 用作列表型別的索引 ('本篇', '特別篇')
                 if len(p) > 0:
                     p = list(map(lambda x: x.contents[0], p))
                 for i in a:
@@ -203,14 +203,14 @@ class Anime:
                         ep = p[index_counter[ep]] + ep
                     self._episode_list[ep] = sn
             except AttributeError:
-                # 当只有一集时，不存在剧集列表，self._episode_list 只有本身
+                # 當只有一集時，不存在劇集列表，self._episode_list 只有本身
                 self._episode_list[self._episode] = self._sn
 
     def __init_header(self):
-        # 伪装为浏览器
+        # 偽裝為瀏覽器
         host = 'ani.gamer.com.tw'
         origin = 'https://' + host
-        ua = self._settings['ua']  # cookie 自动刷新需要 UA 一致
+        ua = self._settings['ua']  # cookie 自動重新整理需要 UA 一致
         ref = 'https://' + host + '/animeVideo.php?sn=' + str(self._sn)
         lang = 'zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.6'
         accept = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8'
@@ -239,7 +239,7 @@ class Anime:
             self._req_header = self._web_header
 
     def __request(self, req, no_cookies=False, show_fail=True, max_retry=3, addition_header=None):
-        # 设置 header
+        # 設定 header
         current_header = self._req_header
         if addition_header is None:
             addition_header = {}
@@ -247,7 +247,7 @@ class Anime:
             for key in addition_header.keys():
                 current_header[key] = addition_header[key]
 
-        # 获取页面
+        # 獲取頁面
         error_cnt = 0
         while True:
             try:
@@ -257,84 +257,84 @@ class Anime:
                     f = self._session.get(req, headers=current_header, cookies={}, timeout=10)
             except requests.exceptions.RequestException as e:
                 if error_cnt >= max_retry >= 0:
-                    raise TryTooManyTimeError('任務狀態: sn=' + str(self._sn) + ' 请求失败次数过多！请求链接：\n%s' % req)
-                err_detail = 'ERROR: 请求失败！except：\n' + str(e) + '\n3s后重试(最多重试' + str(
-                    max_retry) + '次)'
+                    raise TryTooManyTimeError('任務狀態：sn=' + str(self._sn) + ' 請求失敗次數過多！請求連結：\n%s' % req)
+                err_detail = 'ERROR：請求失敗：except：\n' + str(e) + '\n3s 後重試 （最多重試' + str(
+                    max_retry) + '次）'
                 if show_fail:
                     err_print(self._sn, '任務狀態', err_detail)
                 time.sleep(3)
                 error_cnt += 1
             else:
                 break
-        # 处理 cookie
+        # 處理 cookie
         if not self._cookies:
-            # 当实例中尚无 cookie, 则读取
+            # 當例項中尚無 cookie，則讀取
             self._cookies = f.cookies.get_dict()
         elif 'nologinuser' not in self._cookies.keys() and 'BAHAID' not in self._cookies.keys():
-            # 处理游客cookie
+            # 處理訪客 cookie
             if 'nologinuser' in f.cookies.get_dict().keys():
                 # self._cookies['nologinuser'] = f.cookies.get_dict()['nologinuser']
                 self._cookies = f.cookies.get_dict()
-        else:  # 如果用户提供了 cookie, 则处理cookie刷新
-            if 'set-cookie' in f.headers.keys():  # 发现server响应了set-cookie
+        else:  # 如果使用者提供了 cookie，則處理 cookie 重新整理
+            if 'set-cookie' in f.headers.keys():  # 發現 server 響應了 set-cookie
                 if 'deleted' in f.headers.get('set-cookie'):
-                    # set-cookie刷新cookie只有一次机会, 如果其他线程先收到, 则此处会返回 deleted
-                    # 等待其他线程刷新了cookie, 重新读入cookie
+                    # set-cookie重新整理cookie只有一次機會, 如果其他執行緒先收到, 則此處會返回 deleted
+                    # 等待其他執行緒重新整理了cookie, 重新讀入cookie
 
                     if self._settings['use_mobile_api'] and 'X-Bahamut-App-InstanceId' in self._req_header:
-                        # 使用移动API将无法进行 cookie 刷新, 改回 header 刷新 cookie
+                        # 使用 APP API 將無法進行 cookie 重新整理，改回 header 重新整理 cookie
                         self._req_header = self._web_header
-                        self.__request('https://ani.gamer.com.tw/')  # 再次尝试获取新 cookie
+                        self.__request('https://ani.gamer.com.tw/')  # 再次嘗試獲取新 cookie
                     else:
-                        err_print(self._sn, '收到cookie重置響應', display=False)
+                        err_print(self._sn, '收到 cookie 重置回應', display=False)
                         time.sleep(2)
                         try_counter = 0
                         succeed_flag = False
-                        while try_counter < 3:  # 尝试读三次, 不行就算了
+                        while try_counter < 3:  # 嘗試讀三次，不行就算了
                             old_BAHARUNE = self._cookies['BAHARUNE']
                             self._cookies = Config.read_cookie()
-                            err_print(self._sn, '讀取cookie',
-                                      'cookie.txt最後修改時間: ' + Config.get_cookie_time() + ' 第' + str(try_counter) + '次嘗試',
+                            err_print(self._sn, '讀取 cookie',
+                                      'cookie.txt 最後修改時間: ' + Config.get_cookie_time() + ' 第' + str(try_counter) + '次嘗試',
                                       display=False)
                             if old_BAHARUNE != self._cookies['BAHARUNE']:
-                                # 新cookie读取成功 (因为有可能其他线程接到了新cookie)
+                                # 新 cookie 讀取成功（因為有可能其他執行緒接到了新cookie）
                                 succeed_flag = True
-                                err_print(self._sn, '讀取cookie', '新cookie讀取成功', display=False)
+                                err_print(self._sn, '讀取 cookie', '新 cookie 讀取成功', display=False)
                                 break
                             else:
-                                err_print(self._sn, '讀取cookie', '新cookie讀取失敗', display=False)
+                                err_print(self._sn, '讀取 cookie', '新 cookie 讀取失敗', display=False)
                                 random_wait_time = random.uniform(2, 5)
                                 time.sleep(random_wait_time)
                                 try_counter = try_counter + 1
                         if not succeed_flag:
                             self._cookies = {}
-                            err_print(0, '用戶cookie更新失敗! 使用游客身份訪問', status=1, no_sn=True)
-                            Config.invalid_cookie()  # 将失效cookie更名
+                            err_print(0, '用戶 cookie 更新失敗! 使用訪客身份訪問', status=1, no_sn=True)
+                            Config.invalid_cookie()  # 將失效 cookie 更名
 
                         if self._settings['use_mobile_api'] and 'X-Bahamut-App-InstanceId' not in self._req_header:
-                            # 即使切换 header cookie 也无法刷新, 那么恢复 header, 好歹广告只有 3s
+                            # 即使切換 header cookie 也無法重新整理，那麼恢復 header, 好歹廣告只有 3s
                             self._req_header = self._mobile_header
 
                 else:
-                    # 本线程收到了新cookie
-                    # 20220115 简化 cookie 刷新逻辑
-                    err_print(self._sn, '收到新cookie', display=False)
+                    # 本執行緒收到了新 cookie
+                    # 20220115 簡化 cookie 重新整理邏輯
+                    err_print(self._sn, '收到新 cookie', display=False)
 
                     self._cookies.update(f.cookies.get_dict())
                     Config.renew_cookies(self._cookies, log=False)
 
                     key_list_str = ', '.join(f.cookies.get_dict().keys())
-                    err_print(self._sn, f'用戶cookie刷新 {key_list_str} ', display=False)
+                    err_print(self._sn, f'使用者 cookie 更新 {key_list_str} ', display=False)
 
                     self.__request('https://ani.gamer.com.tw/')
-                    # 20210724 动画疯一步到位刷新 Cookie
+                    # 20210724 動畫瘋一步到位重新整理 cookie
                     if 'BAHARUNE' in f.headers.get('set-cookie'):
-                        err_print(0, '用戶cookie已更新', status=2, no_sn=True)
+                        err_print(0, '使用者 cookie 已更新', status=2, no_sn=True)
 
         return f
 
     def __get_m3u8_dict(self):
-        # m3u8获取模块参考自 https://github.com/c0re100/BahamutAnimeDownloader
+        # m3u8 獲取模組參考自 https://github.com/c0re100/BahamutAnimeDownloader
         def get_device_id():
             req = 'https://ani.gamer.com.tw/ajax/getdeviceid.php'
             f = self.__request(req)
@@ -363,12 +363,12 @@ class Anime:
             else:
                 req = 'https://ani.gamer.com.tw/ajax/token.php?adID=0&sn=' + str(
                     self._sn) + "&device=" + self._device_id + "&hash=" + random_string(12)
-            # 返回基础信息, 用于判断是不是VIP
+            # 返回基礎資訊，用於判斷是不是 VIP
             return self.__request(req).json()
 
         def unlock():
             req = 'https://ani.gamer.com.tw/ajax/unlock.php?sn=' + str(self._sn) + "&ttl=0"
-            f = self.__request(req)  # 无响应正文
+            f = self.__request(req)  # 無回應正文
 
         def check_lock():
             req = 'https://ani.gamer.com.tw/ajax/checklock.php?device=' + self._device_id + '&sn=' + str(self._sn)
@@ -379,14 +379,14 @@ class Anime:
                 req = f"https://api.gamer.com.tw/mobile_app/anime/v1/stat_ad.php?schedule=-1&sn={str(self._sn)}"
             else:
                 req = "https://ani.gamer.com.tw/ajax/videoCastcishu.php?sn=" + str(self._sn) + "&s=194699"
-            f = self.__request(req)  # 无响应正文
+            f = self.__request(req)  # 無回應正文
 
         def skip_ad():
             if self._settings['use_mobile_api']:
                 req = f"https://api.gamer.com.tw/mobile_app/anime/v1/stat_ad.php?schedule=-1&ad=end&sn={str(self._sn)}"
             else:
                 req = "https://ani.gamer.com.tw/ajax/videoCastcishu.php?sn=" + str(self._sn) + "&s=194699&ad=end"
-            f = self.__request(req)  # 无响应正文
+            f = self.__request(req)  # 無回應正文
 
         def video_start():
             req = "https://ani.gamer.com.tw/ajax/videoStart.php?sn=" + str(self._sn)
@@ -394,45 +394,45 @@ class Anime:
 
         def check_no_ad(error_count=10):
             if error_count == 0:
-                err_print(self._sn, '廣告去除失敗! 請向開發者提交 issue!', status=1)
+                err_print(self._sn, '廣告去除失敗！請向開發者提交 issue！', status=1)
                 sys.exit(1)
 
-            req = "https://ani.gamer.com.tw/ajax/token.php?sn=" + str(
-                self._sn) + "&device=" + self._device_id + "&hash=" + random_string(12)
+            req = 'https://ani.gamer.com.tw/ajax/token.php?sn=' + str(
+                self._sn) + '&device=' + self._device_id + '&hash=' + random_string(12)
             f = self.__request(req)
             resp = f.json()
             if 'time' in resp.keys():
                 if not resp['time'] == 1:
-                    err_print(self._sn, '廣告似乎還沒去除, 追加等待2秒, 剩餘重試次數 ' + str(error_count), status=1)
+                    err_print(self._sn, '廣告似乎還沒去除，追加等待2秒，剩餘重試次數 ' + str(error_count), status=1)
                     time.sleep(2)
                     skip_ad()
                     video_start()
                     check_no_ad(error_count=error_count - 1)
                 else:
-                    # 通过广告检查
+                    # 透過廣告檢查
                     if error_count != 10:
                         ads_time = (10-error_count)*2 + ad_time + 2
-                        err_print(self._sn, '通过廣告時間' + str(ads_time) + '秒, 記錄到配置檔案', status=2)
+                        err_print(self._sn, '透過廣告時間' + str(ads_time) + '秒，記錄到設定檔案', status=2)
                         if self._settings['use_mobile_api']:
                             self._settings['mobile_ads_time'] = ads_time
                         else:
                             self._settings['ads_time'] = ads_time
-                        Config.write_settings(self._settings)  # 保存到配置文件
+                        Config.write_settings(self._settings)  # 儲存到設定檔案
             else:
-                err_print(self._sn, '遭到動畫瘋地區限制, 你的IP可能不被動畫瘋認可!', status=1)
+                err_print(self._sn, '遭到動畫瘋地區限制，你的 IP 可能不被動畫瘋認可！', status=1)
                 sys.exit(1)
 
         def parse_playlist():
             req = self._playlist['src']
-            f = self.__request(req, no_cookies=True, addition_header={"referer": "https://ani.gamer.com.tw/"})
-            url_prefix = re.sub(r'playlist.+', '', self._playlist['src'])  # m3u8 URL 前缀
-            m3u8_list = re.findall(r'=\d+x\d+\n.+', f.content.decode())  # 将包含分辨率和 m3u8 文件提取
+            f = self.__request(req, no_cookies=True, addition_header={'referer': 'https://ani.gamer.com.tw/'})
+            url_prefix = re.sub(r'playlist.+', '', self._playlist['src'])  # m3u8 URL 字首
+            m3u8_list = re.findall(r'=\d+x\d+\n.+', f.content.decode())  # 將包含解析度和 m3u8 檔案提取
             m3u8_dict = {}
             for i in m3u8_list:
-                key = re.findall(r'=\d+x\d+', i)[0]  # 提取分辨率
-                key = re.findall(r'x\d+', key)[0][1:]  # 提取纵向像素数，作为 key
-                value = re.findall(r'.*chunklist.+', i)[0]  # 提取 m3u8 文件
-                value = url_prefix + value  # 组成完整的 m3u8 URL
+                key = re.findall(r'=\d+x\d+', i)[0]  # 提取解析度
+                key = re.findall(r'x\d+', key)[0][1:]  # 提取縱向畫素數，作為 key
+                value = re.findall(r'.*chunklist.+', i)[0]  # 提取 m3u8 檔案
+                value = url_prefix + value  # 組成完整的 m3u8 URL
                 m3u8_dict[key] = value
             self._m3u8_dict = m3u8_dict
 
@@ -445,7 +445,7 @@ class Anime:
             unlock()
 
         # 收到錯誤反饋
-        # 可能是限制級動畫要求登陸
+        # 可能是限制級動畫要求登入
         if 'error' in user_info.keys():
             msg = '《' + self._title + '》 '
             msg = msg + 'code=' + str(user_info['error']['code']) + ' message: ' + user_info['error']['message']
@@ -453,25 +453,25 @@ class Anime:
             sys.exit(1)
 
         if not user_info['vip']:
-            # 如果用户不是 VIP, 那么等待广告(20s)
-            # 20200513 网站更新，最低广告更新时间从8s增加到20s https://github.com/miyouzi/aniGamerPlus/issues/41
-            # 20200806 网站更新，最低广告更新时间从20s增加到25s https://github.com/miyouzi/aniGamerPlus/issues/55
+            # 如果使用者不是 VIP, 那麼等待廣告(20s)
+            # 20200513 網站更新，最低廣告更新時間從8s增加到20s https://github.com/miyouzi/aniGamerPlus/issues/41
+            # 20200806 網站更新，最低廣告更新時間從20s增加到25s https://github.com/miyouzi/aniGamerPlus/issues/55
 
             if self._settings['only_use_vip']:
-                 err_print(self._sn, '非VIP','因為已設定只使用VIP下載，故強制停止', status=1, no_sn=True)
+                 err_print(self._sn, '非 VIP','因為已設定只使用 VIP 下載，故強制停止', status=1, no_sn=True)
                  sys.exit(1)
 
             if self._settings['use_mobile_api']:
-                ad_time = self._settings['mobile_ads_time']  # APP解析廣告解析時間不同
+                ad_time = self._settings['mobile_ads_time']  # APP 解析廣告解析時間不同
             else:
                 ad_time = self._settings['ads_time']
 
-            err_print(self._sn, '正在等待', '《' + self.get_title() + '》 由於不是VIP賬戶, 正在等待'+str(ad_time)+'s廣告時間')
+            err_print(self._sn, '正在等待', '《' + self.get_title() + '》 由於不是 VIP 帳號，正在等待'+str(ad_time)+'s 廣告時間')
             start_ad()
             time.sleep(ad_time)
             skip_ad()
         else:
-            err_print(self._sn, '開始下載', '《' + self.get_title() + '》 識別到VIP賬戶, 立即下載')
+            err_print(self._sn, '開始下載', '《' + self.get_title() + '》 識別到 VIP 帳號，立即下載')
 
         if not self._settings['use_mobile_api']:
             video_start()
@@ -485,93 +485,93 @@ class Anime:
         return self._m3u8_dict
 
     def __get_filename(self, resolution, without_suffix=False):
-        # 处理剧集名补零
+        # 處理劇集名補零
         if re.match(r'^[+-]?\d+(\.\d+){0,1}$', self._episode) and self._settings['zerofill'] > 1:
-            # 正则考虑到了带小数点的剧集
-            # 如果剧集名为数字, 且用户开启补零
+            # 正則考慮到了帶小數點的劇集
+            # 如果劇集名為數字, 且使用者開啟補零
             if re.match(r'^\d+\.\d+$', self._episode):
-                # 如果是浮点数
+                # 如果是浮點數
                 a = re.findall(r'^\d+\.', self._episode)[0][:-1]
                 b = re.findall(r'\.\d+$', self._episode)[0]
                 episode = '[' + a.zfill(self._settings['zerofill']) + b + ']'
             else:
-                # 如果是整数
+                # 如果是整數
                 episode = '[' + self._episode.zfill(self._settings['zerofill']) + ']'
         else:
             episode = '[' + self._episode + ']'
 
         if self._settings['add_bangumi_name_to_video_filename']:
-            # 如果用户需要番剧名
+            # 如果使用者需要番劇名
             bangumi_name = self._settings['customized_video_filename_prefix'] \
                            + self._bangumi_name \
                            + self._settings['customized_bangumi_name_suffix']
 
-            filename = bangumi_name + episode  # 有番剧名的文件名
+            filename = bangumi_name + episode  # 有番劇名的檔名
         else:
-            # 如果用户不要将番剧名添加到文件名
+            # 如果使用者不要將番劇名新增到檔名
             filename = self._settings['customized_video_filename_prefix'] + episode
 
-        # 添加分辨率后缀
+        # 新增解析度字尾
         if self._settings['add_resolution_to_video_filename']:
             filename = filename + '[' + resolution + 'P]'
 
         if without_suffix:
-            return filename  # 截止至清晰度的文件名, 用于 __get_temp_filename()
+            return filename  # 截止至解析度的檔名, 用於 __get_temp_filename()
 
-        # 添加用户后缀及扩展名
+        # 新增使用者字尾及副檔名
         filename = filename + self._settings['customized_video_filename_suffix'] \
                    + '.' + self._settings['video_filename_extension']
-        legal_filename = Config.legalize_filename(filename)  # 去除非法字符
+        legal_filename = Config.legalize_filename(filename)  # 去除非法字元
         filename = legal_filename
         return filename
 
     def __get_temp_filename(self, resolution, temp_suffix):
         filename = self.__get_filename(resolution, without_suffix=True)
-        # temp_filename 为临时文件名，下载完成后更名正式文件名
+        # temp_filename 為臨時檔名，下載完成後更名正式檔名
         temp_filename = filename + self._settings['customized_video_filename_suffix'] + '.' + temp_suffix \
                         + '.' + self._settings['video_filename_extension']
         temp_filename = Config.legalize_filename(temp_filename)
         return temp_filename
 
     def __segment_download_mode(self, resolution=''):
-        # 设定文件存放路径
+        # 設定檔案存放路徑
         filename = self.__get_filename(resolution)
         merging_filename = self.__get_temp_filename(resolution, temp_suffix='MERGING')
 
-        output_file = os.path.join(self._bangumi_dir, filename)  # 完整输出路径
+        output_file = os.path.join(self._bangumi_dir, filename)  # 完整輸出路徑
         merging_file = os.path.join(self._temp_dir, merging_filename)
 
-        url_path = os.path.split(self._m3u8_dict[resolution])[0]  # 用于构造完整 chunk 链接
-        temp_dir = os.path.join(self._temp_dir, str(self._sn) + '-downloading-by-aniGamerPlus')  # 临时目录以 sn 命令
-        if not os.path.exists(temp_dir):  # 创建临时目录
+        url_path = os.path.split(self._m3u8_dict[resolution])[0]  # 用於構造完整 chunk 連結
+        temp_dir = os.path.join(self._temp_dir, str(self._sn) + '-downloading-by-aniGamerPlus')  # 臨時目錄以 sn 命令
+        if not os.path.exists(temp_dir):  # 建立臨時目錄
             os.makedirs(temp_dir)
         m3u8_path = os.path.join(temp_dir, str(self._sn) + '.m3u8')  # m3u8 存放位置
-        m3u8_text = self.__request(self._m3u8_dict[resolution], no_cookies=True).text  # 请求 m3u8 文件
-        with open(m3u8_path, 'w', encoding='utf-8') as f:  # 保存 m3u8 文件在本地
+        m3u8_text = self.__request(self._m3u8_dict[resolution], no_cookies=True).text  # 請求 m3u8 檔案
+        with open(m3u8_path, 'w', encoding='utf-8') as f:  # 儲存 m3u8 檔案在本地
             f.write(m3u8_text)
             pass
-        key_uri = re.search(r'(?<=AES-128,URI=")(.*)(?=")', m3u8_text).group()  # 把 key 的链接提取出来
+        key_uri = re.search(r'(?<=AES-128,URI=")(.*)(?=")', m3u8_text).group()  # 把 key 的連結提取出來
         original_key_uri = key_uri
 
         if not re.match(r'http.+', key_uri):
             # https://github.com/miyouzi/aniGamerPlus/issues/46
             # 如果不是完整的URI
-            key_uri = url_path + '/' + key_uri  # 组成完成的 URI
+            key_uri = url_path + '/' + key_uri  # 組成完成的 URI
 
         m3u8_key_path = os.path.join(temp_dir, 'key.m3u8key')  # key 的存放位置
-        with open(m3u8_key_path, 'wb') as f:  # 保存 key
+        with open(m3u8_key_path, 'wb') as f:  # 儲存 key
             f.write(self.__request(key_uri, no_cookies=True).content)
 
         chunk_list = re.findall(r'media_b.+ts.*', m3u8_text)  # chunk
 
-        limiter = threading.Semaphore(self._settings['multi_downloading_segment'])  # chunk 并发下载限制器
+        limiter = threading.Semaphore(self._settings['multi_downloading_segment'])  # chunk 併發下載限制器
         total_chunk_num = len(chunk_list)
         finished_chunk_counter = 0
         failed_flag = False
 
         def download_chunk(uri):
-            chunk_name = re.findall(r'media_b.+ts', uri)[0]  # chunk 文件名
-            chunk_local_path = os.path.join(temp_dir, chunk_name)  # chunk 路径
+            chunk_name = re.findall(r'media_b.+ts', uri)[0]  # chunk 檔案名稱
+            chunk_local_path = os.path.join(temp_dir, chunk_name)  # chunk 路徑
             nonlocal failed_flag
 
             try:
@@ -586,11 +586,11 @@ class Anime:
                 sys.exit(1)
             except BaseException as e:
                 failed_flag = True
-                err_print(self._sn, '下載狀態', 'Bad segment=' + chunk_name + ' 發生未知錯誤: ' + str(e), status=1)
+                err_print(self._sn, '下載狀態', 'Bad segment=' + chunk_name + ' 發生未知錯誤：' + str(e), status=1)
                 limiter.release()
                 sys.exit(1)
 
-            # 显示完成百分比
+            # 顯示完成百分比
             nonlocal finished_chunk_counter
             finished_chunk_counter = finished_chunk_counter + 1
             progress_rate = float(finished_chunk_counter / total_chunk_num * 100)
@@ -598,13 +598,13 @@ class Anime:
             Config.tasks_progress_rate[int(self._sn)]['rate'] = progress_rate
 
             if self.realtime_show_file_size:
-                sys.stdout.write('\r正在下載: sn=' + str(self._sn) + ' ' + filename + ' ' + str(progress_rate) + '%  ')
+                sys.stdout.write('\r正在下載：sn=' + str(self._sn) + ' ' + filename + ' ' + str(progress_rate) + '%  ')
                 sys.stdout.flush()
             limiter.release()
 
         if self.realtime_show_file_size:
-            # 是否实时显示文件大小, 设计仅 cui 下载单个文件或线程数=1时适用
-            sys.stdout.write('正在下載: sn=' + str(self._sn) + ' ' + filename)
+            # 是否實時顯示檔案大小，設計僅 cui 下載單個檔案或執行緒數 =1 時適用
+            sys.stdout.write('正在下載：sn=' + str(self._sn) + ' ' + filename)
             sys.stdout.flush()
         else:
             err_print(self._sn, '正在下載', filename + ' title=' + self._title)
@@ -618,10 +618,10 @@ class Anime:
             limiter.acquire()
             task.start()
 
-        for task in chunk_tasks_list:  # 等待所有任务完成
+        for task in chunk_tasks_list:  # 等待所有任務完成
             while True:
                 if failed_flag:
-                    err_print(self._sn, '下載失败', filename, status=1)
+                    err_print(self._sn, '下載失敗', filename, status=1)
                     self.video_size = 0
                     return
                 if task.is_alive():
@@ -630,22 +630,22 @@ class Anime:
                     break
 
         # m3u8 本地化
-        # replace('\\', '\\\\') 为转义win路径
+        # replace('\\', '\\\\') 為轉譯win路徑
         m3u8_text_local_version = m3u8_text.replace(original_key_uri, os.path.join(temp_dir, 'key.m3u8key')).replace('\\', '\\\\')
         for chunk in chunk_list:
-            chunk_filename = re.findall(r'media_b.+ts', chunk)[0]  # chunk 文件名
-            chunk_path = os.path.join(temp_dir, chunk_filename).replace('\\', '\\\\')  # chunk 本地路径
+            chunk_filename = re.findall(r'media_b.+ts', chunk)[0]  # chunk 檔名
+            chunk_path = os.path.join(temp_dir, chunk_filename).replace('\\', '\\\\')  # chunk 本地路徑
             m3u8_text_local_version = m3u8_text_local_version.replace(chunk, chunk_path)
-        with open(m3u8_path, 'w', encoding='utf-8') as f:  # 保存本地化的 m3u8
+        with open(m3u8_path, 'w', encoding='utf-8') as f:  # 儲存本地化的 m3u8
             f.write(m3u8_text_local_version)
 
         if self.realtime_show_file_size:
             sys.stdout.write('\n')
             sys.stdout.flush()
-        err_print(self._sn, '下載狀態', filename + ' 下載完成, 正在解密合并……')
+        err_print(self._sn, '下載狀態', filename + ' 下載完成，正在解密合併……')
         Config.tasks_progress_rate[int(self._sn)]['status'] = '下載完成'
 
-        # 构造 ffmpeg 命令
+        # 構造 ffmpeg 命令
         ffmpeg_cmd = [self._ffmpeg_path,
                       '-allowed_extensions', 'ALL',
                       '-i', m3u8_path,
@@ -653,8 +653,8 @@ class Anime:
                       '-y']
 
         if self._settings['faststart_movflags']:
-            # 将 metadata 移至视频文件头部
-            # 此功能可以更快的在线播放视频
+            # 將 metadata 移至影片檔案頭部
+            # 此功能可以更快的線上播放影片
             ffmpeg_cmd[7:7] = iter(['-movflags', 'faststart'])
 
         if self._settings['audio_language']:
@@ -663,39 +663,39 @@ class Anime:
             else:
                 ffmpeg_cmd[7:7] = iter(['-metadata:s:a:0', 'language=chi'])
 
-        # 执行 ffmpeg
+        # 執行 ffmpeg
         run_ffmpeg = subprocess.Popen(ffmpeg_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         run_ffmpeg.communicate()
-        # 记录文件大小，单位为 MB
+        # 記錄檔案大小，單位為 MB
         self.video_size = int(os.path.getsize(merging_file) / float(1024 * 1024))
         # 重命名
-        err_print(self._sn, '下載狀態', filename + ' 解密合并完成, 本集 ' + str(self.video_size) + 'MB, 正在移至番劇目錄……')
+        err_print(self._sn, '下載狀態', filename + ' 解密合併完成，本集 ' + str(self.video_size) + 'MB，正在移至番劇目錄……')
         if os.path.exists(output_file):
             os.remove(output_file)
 
         if self._settings['use_copyfile_method']:
-            shutil.copyfile(merging_file, output_file)  # 适配rclone挂载盘
-            os.remove(merging_file)  # 刪除临时合并文件
+            shutil.copyfile(merging_file, output_file)  # 配合 rclone 掛載
+            os.remove(merging_file)  # 刪除臨時合併檔案
         else:
-            shutil.move(merging_file, output_file)  # 此方法在遇到rclone挂载盘时会出错
+            shutil.move(merging_file, output_file)  # 此方法在遇到 rclone 掛載時會出錯
 
-        # 删除临时目录
+        # 刪除臨時目錄
         shutil.rmtree(temp_dir, ignore_errors=True)
 
-        self.local_video_path = output_file  # 记录保存路径, FTP上传用
-        self._video_filename = filename  # 记录文件名, FTP上传用
+        self.local_video_path = output_file  # 記錄儲存路徑，FTP 上傳用
+        self._video_filename = filename  # 記錄檔名，FTP 上傳用
 
         err_print(self._sn, '下載完成', filename, status=2)
 
     def __ffmpeg_download_mode(self, resolution=''):
-        # 设定文件存放路径
+        # 設定檔案存放路徑
         filename = self.__get_filename(resolution)
         downloading_filename = self.__get_temp_filename(resolution, temp_suffix='DOWNLOADING')
 
-        output_file = os.path.join(self._bangumi_dir, filename)  # 完整输出路径
+        output_file = os.path.join(self._bangumi_dir, filename)  # 完整输出路徑
         downloading_file = os.path.join(self._temp_dir, downloading_filename)
 
-        # 构造 ffmpeg 命令
+        # 建構 ffmpeg 命令
         ffmpeg_cmd = [self._ffmpeg_path,
                       '-user_agent',
                       self._settings['ua'],
@@ -705,15 +705,15 @@ class Anime:
                       '-y']
 
         if os.path.exists(downloading_file):
-            os.remove(downloading_file)  # 清理任务失败的尸体
+            os.remove(downloading_file)  # 清理任務失敗的屍體
 
-        # subprocess.call(ffmpeg_cmd, creationflags=0x08000000)  # 仅windows
+        # subprocess.call(ffmpeg_cmd, creationflags=0x08000000)  # 僅 windows
         run_ffmpeg = subprocess.Popen(ffmpeg_cmd, stdout=subprocess.PIPE, bufsize=204800, stderr=subprocess.PIPE)
 
         def check_ffmpeg_alive():
-            # 应对ffmpeg卡死, 资源限速等，若 1min 中内文件大小没有增加超过 3M, 则判定卡死
-            if self.realtime_show_file_size:  # 是否实时显示文件大小, 设计仅 cui 下载单个文件或线程数=1时适用
-                sys.stdout.write('正在下載: sn=' + str(self._sn) + ' ' + filename)
+            # 應對 ffmpeg 卡死，資源限速等，若 1min 中內檔案大小沒有增加超過 3M，則判定卡死
+            if self.realtime_show_file_size:  # 是否實時顯示檔案大小，設計僅 cui 下載單個檔案或執行緒數 =1 時適用
+                sys.stdout.write('正在下載：sn=' + str(self._sn) + ' ' + filename)
                 sys.stdout.flush()
             else:
                 err_print(self._sn, '正在下載', filename + ' title=' + self._title)
@@ -724,24 +724,24 @@ class Anime:
             while run_ffmpeg.poll() is None:
 
                 if self.realtime_show_file_size:
-                    # 实时显示文件大小
+                    # 即時顯示檔案大小
                     if os.path.exists(downloading_file):
                         size = os.path.getsize(downloading_file)
                         size = size / float(1024 * 1024)
                         size = round(size, 2)
                         sys.stdout.write(
-                            '\r正在下載: sn=' + str(self._sn) + ' ' + filename + '    ' + str(size) + 'MB      ')
+                            '\r正在下載：sn=' + str(self._sn) + ' ' + filename + '    ' + str(size) + 'MB      ')
                         sys.stdout.flush()
                     else:
-                        sys.stdout.write('\r正在下載: sn=' + str(self._sn) + ' ' + filename + '    文件尚未生成  ')
+                        sys.stdout.write('\r正在下載：sn=' + str(self._sn) + ' ' + filename + '    檔案尚未生成  ')
                         sys.stdout.flush()
 
                 if time_counter % 60 == 0 and os.path.exists(downloading_file):
                     temp_file_size = os.path.getsize(downloading_file)
                     a = temp_file_size - pre_temp_file_size
                     if a < (3 * 1024 * 1024):
-                        err_msg_detail = downloading_filename + ' 在一分钟内仅增加' + str(
-                            int(a / float(1024))) + 'KB 判定为卡死, 任务失败!'
+                        err_msg_detail = downloading_filename + ' 在一分鐘內僅增加' + str(
+                            int(a / float(1024))) + 'KB 判定為卡死，任務失敗！'
                         err_print(self._sn, '下載失败', err_msg_detail, status=1)
                         run_ffmpeg.kill()
                         return
@@ -749,8 +749,8 @@ class Anime:
                 time.sleep(1)
                 time_counter = time_counter + 1
 
-        ffmpeg_checker = threading.Thread(target=check_ffmpeg_alive)  # 检查线程
-        ffmpeg_checker.setDaemon(True)  # 如果 Anime 线程被 kill, 检查进程也应该结束
+        ffmpeg_checker = threading.Thread(target=check_ffmpeg_alive)  # 檢查執行緒
+        ffmpeg_checker.setDaemon(True)  # 如果 Anime 執行緒被 kill, 檢查程式也應該結束
         ffmpeg_checker.start()
         run = run_ffmpeg.communicate()
         return_str = str(run[1])
@@ -760,26 +760,26 @@ class Anime:
             sys.stdout.flush()
 
         if run_ffmpeg.returncode == 0 and (return_str.find('Failed to open segment') < 0):
-            # 执行成功 (ffmpeg正常结束, 每个分段都成功下载)
+            # 執行成功（ffmpeg正常結束，每個分段都成功下載）
             if os.path.exists(output_file):
                 os.remove(output_file)
-            # 记录文件大小，单位为 MB
+            # 記錄檔案大小，單位為 MB
             self.video_size = int(os.path.getsize(downloading_file) / float(1024 * 1024))
-            err_print(self._sn, '下載狀態', filename + '本集 ' + str(self.video_size) + 'MB, 正在移至番劇目錄……')
+            err_print(self._sn, '下載狀態', filename + '本集 ' + str(self.video_size) + 'MB，正在移至番劇目錄……')
 
             if self._settings['use_copyfile_method']:
-                shutil.copyfile(downloading_file, output_file)  # 适配rclone挂载盘
-                os.remove(downloading_file)  # 刪除临时合并文件
+                shutil.copyfile(downloading_file, output_file)  # 配合 rclone 掛載
+                os.remove(downloading_file)  # 刪除臨時合併檔案
             else:
-                shutil.move(downloading_file, output_file)  # 此方法在遇到rclone挂载盘时会出错
+                shutil.move(downloading_file, output_file)  # 此方法在遇到 rclone 掛載時會出錯
 
-            self.local_video_path = output_file  # 记录保存路径, FTP上传用
-            self._video_filename = filename  # 记录文件名, FTP上传用
+                self.local_video_path = output_file  # 記錄儲存路徑，FTP 上傳用
+                self._video_filename = filename  # 記錄檔名，FTP 上傳用
             err_print(self._sn, '下載完成', filename, status=2)
         else:
             err_msg_detail = filename + ' ffmpeg_return_code=' + str(
                 run_ffmpeg.returncode) + ' Bad segment=' + str(return_str.find('Failed to open segment'))
-            err_print(self._sn, '下載失败', err_msg_detail, status=1)
+            err_print(self._sn, '下載失敗', err_msg_detail, status=1)
 
     def download(self, resolution='', save_dir='', bangumi_tag='', realtime_show_file_size=False, rename='', classify=True):
         self.realtime_show_file_size = realtime_show_file_size
@@ -787,66 +787,66 @@ class Anime:
             resolution = self._settings['download_resolution']
 
         if save_dir:
-            self._bangumi_dir = save_dir  # 用于 cui 用户指定下载在当前目录
+            self._bangumi_dir = save_dir  # 用於 cui 使用者指定下載在當前目錄
 
         if rename:
             bangumi_name = self._bangumi_name
-            # 适配多版本的番剧
-            version = re.findall(r'\[.+?\]', self._bangumi_name)  # 在番剧名中寻找是否存在多版本标记
-            if version:  # 如果这个番剧是多版本的
-                version = str(version[-1])  # 提取番剧版本名称
-                bangumi_name = bangumi_name.replace(version, '').strip()  # 没有版本名称的 bangumi_name, 且头尾无空格
-            # 如果设定重命名了番剧
-            # 将其中的番剧名换成用户设定的, 且不影响版本号后缀(如果有)
+            # 適配多版本的番劇
+            version = re.findall(r'\[.+?\]', self._bangumi_name)  # 在番劇名中尋找是否存在多版本標記
+            if version:  # 如果這個番劇是多版本的
+                version = str(version[-1])  # 提取番劇版本名稱
+                bangumi_name = bangumi_name.replace(version, '').strip()  # 沒有版本名稱的 bangumi_name，且頭尾無空格
+            # 如果設定重新命名了番劇
+            # 將其中的番劇名換成使用者設定的，且不影響版本號字尾（如果有）
             self._title = self._title.replace(bangumi_name, rename)
             self._bangumi_name = self._bangumi_name.replace(bangumi_name, rename)
 
-        # 下载任务开始
+        # 下載任務開始
         Config.tasks_progress_rate[int(self._sn)] = {'rate': 0, 'filename': '《'+self.get_title()+'》', 'status': '正在解析'}
 
         try:
-            self.__get_m3u8_dict()  # 获取 m3u8 列表
+            self.__get_m3u8_dict()  # 獲取 m3u8 列表
         except TryTooManyTimeError:
-            # 如果在获取 m3u8 过程中发生意外, 则取消此次下载
-            err_print(self._sn, '下載狀態', '獲取 m3u8 失敗!', status=1)
+            # 如果在獲取 m3u8 過程中發生意外, 則取消此次下載
+            err_print(self._sn, '下載狀態', '獲取 m3u8 失敗！', status=1)
             self.video_size = 0
             return
 
         check_ffmpeg = subprocess.Popen('ffmpeg -h', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if check_ffmpeg.stdout.readlines():  # 查找 ffmpeg 是否已放入系统 path
+        if check_ffmpeg.stdout.readlines():  # 查詢 ffmpeg 是否已放入系統 path
             self._ffmpeg_path = 'ffmpeg'
         else:
-            # print('没有在系统PATH中发现ffmpeg，尝试在所在目录寻找')
+            # print('沒有在系統 PATH 中發現 ffmpeg，嘗試在所在目錄尋找')
             if 'Windows' in platform.system():
                 self._ffmpeg_path = os.path.join(self._working_dir, 'ffmpeg.exe')
             else:
                 self._ffmpeg_path = os.path.join(self._working_dir, 'ffmpeg')
             if not os.path.exists(self._ffmpeg_path):
-                err_print(0, '本項目依賴於ffmpeg, 但ffmpeg未找到', status=1, no_sn=True)
-                raise FileNotFoundError  # 如果本地目录下也没有找到 ffmpeg 则丢出异常
+                err_print(0, '本專案依賴於 ffmpeg，但 ffmpeg 未找到', status=1, no_sn=True)
+                raise FileNotFoundError  # 如果本地目錄下也沒有找到 ffmpeg 則丟出異常
 
-        # 创建存放番剧的目录，去除非法字符
-        if bangumi_tag:  # 如果指定了番剧分类
+        # 建立存放番劇的目錄，去除非法字元
+        if bangumi_tag:  # 如果指定了番劇分類
             self._bangumi_dir = os.path.join(self._bangumi_dir, Config.legalize_filename(bangumi_tag))
-        if classify:  # 控制是否建立番剧文件夹
+        if classify:  # 控制是否建立番劇資料夾
             self._bangumi_dir = os.path.join(self._bangumi_dir, Config.legalize_filename(self._bangumi_name))
         if not os.path.exists(self._bangumi_dir):
             try:
-                os.makedirs(self._bangumi_dir)  # 按番剧创建文件夹分类
+                os.makedirs(self._bangumi_dir)  # 按番劇建立資料夾分類
             except FileExistsError as e:
-                err_print(self._sn, '下載狀態', '慾創建的番劇資料夾已存在 ' + str(e), display=False)
+                err_print(self._sn, '下載狀態', '欲建立的番劇資料夾已存在 ' + str(e), display=False)
 
-        if not os.path.exists(self._temp_dir):  # 建立临时文件夹
+        if not os.path.exists(self._temp_dir):  # 建立臨時資料夾
             try:
                 os.makedirs(self._temp_dir)
             except FileExistsError as e:
-                err_print(self._sn, '下載狀態', '慾創建的臨時資料夾已存在 ' + str(e), display=False)
+                err_print(self._sn, '下載狀態', '欲建立的臨時資料夾已存在 ' + str(e), display=False)
 
-        # 如果不存在指定清晰度，则选取最近可用清晰度
+        # 如果不存在指定解析度，則選取最近可用解析度
         if resolution not in self._m3u8_dict.keys():
             if self._settings['lock_resolution']:
-                # 如果用户设定锁定清晰度, 則下載取消
-                err_msg_detail = '指定清晰度不存在, 因當前鎖定了清晰度, 下載取消. 可用的清晰度: ' + 'P '.join(self._m3u8_dict.keys()) + 'P'
+                # 如果使用者設定鎖定解析度，則下載取消
+                err_msg_detail = '指定解析度不存在，因當前鎖定了解析度，下載取消，可用的解析度：' + 'P '.join(self._m3u8_dict.keys()) + 'P'
                 err_print(self._sn, '任務狀態', err_msg_detail, status=1)
                 return
 
@@ -860,13 +860,13 @@ class Anime:
                     flag = a
                     closest_resolution = i
             # resolution_list.sort()
-            # resolution = str(resolution_list[-1])  # 选取最高可用清晰度
+            # resolution = str(resolution_list[-1])  # 選取最高可用解析度
             resolution = str(closest_resolution)
-            err_msg_detail = '指定清晰度不存在, 選取最近可用清晰度: ' + resolution + 'P'
+            err_msg_detail = '指定解析度不存在，選取最近可用解析度：' + resolution + 'P'
             err_print(self._sn, '任務狀態', err_msg_detail, status=1)
         self.video_resolution = int(resolution)
 
-        # 解析完成, 开始下载
+        # 解析完成，開始下載
         Config.tasks_progress_rate[int(self._sn)]['status'] = '正在下載'
         Config.tasks_progress_rate[int(self._sn)]['filename'] = self.get_filename()
 
@@ -875,7 +875,7 @@ class Anime:
         else:
             self.__ffmpeg_download_mode(resolution)
 
-        # 任务完成, 从任务进度表中删除
+        # 任務完成，從任務進度表中刪除
         del Config.tasks_progress_rate[int(self._sn)]
 
         # 下載彈幕
@@ -887,9 +887,9 @@ class Anime:
         # 推送 CQ 通知
         if self._settings['coolq_notify']:
             try:
-                msg = '【aniGamerPlus消息】\n《' + self._video_filename + '》下载完成, 本集 ' + str(self.video_size) + ' MB'
+                msg = '【aniGamerPlus消息】\n《' + self._video_filename + '》下载完成，本集 ' + str(self.video_size) + ' MB'
                 if self._settings['coolq_settings']['message_suffix']:
-                    # 追加用户信息
+                    # 追加使用者資訊
                     msg = msg + '\n\n' + self._settings['coolq_settings']['message_suffix']
 
                 for query in self._settings['coolq_settings']['query']:
@@ -905,7 +905,7 @@ class Anime:
         # 推送 TG 通知
         if self._settings['telebot_notify']:
             try:
-                msg = '【aniGamerPlus消息】\n《' + self._video_filename + '》下载完成, 本集 ' + str(self.video_size) + ' MB'
+                msg = '【aniGamerPlus消息】\n《' + self._video_filename + '》下载完成，本集 ' + str(self.video_size) + ' MB'
                 vApiTokenTelegram = self._settings['telebot_token']
                 apiMethod = "getUpdates"
                 api_url = "https://api.telegram.org/bot" + vApiTokenTelegram + "/" + apiMethod # Telegram bot api url
@@ -922,9 +922,9 @@ class Anime:
                                 + str(chat_id) \
                                 + "&text=" \
                                 + str(msg)
-                        self.__request(req, no_cookies=True) # Send msg to telegram bot
+                        self.__request(req, no_cookies=True)  # Send msg to telegram bot
                     except:
-                        err_print(self._sn, 'TG NOTIFY ERROR', "Exception: Send msg error\nReq: " + req, status=1) # Send mag error
+                        err_print(self._sn, 'TG NOTIFY ERROR', "Exception: Send msg error\nReq: " + req, status=1)  # Send mag error
                 except:
                     err_print(self._sn, 'TG NOTIFY ERROR', "Exception: Invalid access token\nToken: " + vApiTokenTelegram, status=1) # Cannot find chat id
             except BaseException as e:
@@ -945,7 +945,7 @@ class Anime:
                     }}]}
             r = requests.post(url, json=data)
             if r.status_code != 200:
-                err_print(self._sn, 'discord NOTIFY ERROR', "Exception: Send msg error\nReq: " + req, status=1)
+                err_print(self._sn, 'discord NOTIFY ERROR', 'Exception: Send msg error\nReq: ' + req, status=1)
 
         # plex 自動更新媒體庫
         if self._settings['plex_refresh']:
@@ -959,19 +959,19 @@ class Anime:
                 err_print(self._sn, 'Plex auto Refresh ERROR', status=1)
 
     def upload(self, bangumi_tag='', debug_file=''):
-        first_connect = True  # 标记是否是第一次连接, 第一次连接会删除临时缓存目录
+        first_connect = True  # 標記是否是第一次連線，第一次連線會刪除臨時快取目錄
         tmp_dir = str(self._sn) + '-uploading-by-aniGamerPlus'
 
         if debug_file:
             self.local_video_path = debug_file
 
-        if not os.path.exists(self.local_video_path):  # 如果文件不存在,直接返回失败
+        if not os.path.exists(self.local_video_path):  # 如果檔案不存在,直接返回失敗
             return self.upload_succeed_flag
 
-        if not self._video_filename:  # 用于仅上传, 将文件名提取出来
+        if not self._video_filename:  # 用於僅上傳, 將檔名提取出來
             self._video_filename = os.path.split(self.local_video_path)[-1]
 
-        socket.setdefaulttimeout(20)  # 超时时间20s
+        socket.setdefaulttimeout(20)  # 超時時間20s
 
         if self._settings['ftp']['tls']:
             ftp = FTP_TLS()  # FTP over TLS
@@ -979,46 +979,46 @@ class Anime:
             ftp = FTP()
 
         def connect_ftp(show_err=True):
-            ftp.encoding = 'utf-8'  # 解决中文乱码
+            ftp.encoding = 'utf-8'  # 解決中文亂碼
             err_counter = 0
             connect_flag = False
             while err_counter <= 3:
                 try:
-                    ftp.connect(self._settings['ftp']['server'], self._settings['ftp']['port'])  # 连接 FTP
-                    ftp.login(self._settings['ftp']['user'], self._settings['ftp']['pwd'])  # 登陆
+                    ftp.connect(self._settings['ftp']['server'], self._settings['ftp']['port'])  # 連線 FTP
+                    ftp.login(self._settings['ftp']['user'], self._settings['ftp']['pwd'])  # 登入
                     connect_flag = True
                     break
                 except ftplib.error_temp as e:
                     if show_err:
                         if 'Too many connections' in str(e):
-                            detail = self._video_filename + ' 当前FTP連接數過多, 5分鐘后重試, 最多重試三次: ' + str(e)
-                            err_print(self._sn, 'FTP狀態', detail, status=1)
+                            detail = self._video_filename + ' 當前 FTP 連線數過多, 5 分鐘後重試，最多重試三次：' + str(e)
+                            err_print(self._sn, 'FTP 狀態', detail, status=1)
                         else:
-                            detail = self._video_filename + ' 連接FTP時發生錯誤, 5分鐘后重試, 最多重試三次: ' + str(e)
-                            err_print(self._sn, 'FTP狀態', detail, status=1)
-                    err_counter = err_counter + 1
-                    for i in range(5 * 60):
-                        time.sleep(1)
+                            detail = self._video_filename + ' 連線FTP時發生錯誤，5 分鐘後重試，最多重試三次：' + str(e)
+                            err_print(self._sn, 'FTP 狀態', detail, status=1)
+                        err_counter = err_counter + 1
+                        for i in range(5 * 60):
+                            time.sleep(1)
                 except BaseException as e:
                     if show_err:
-                        detail = self._video_filename + ' 在連接FTP時發生無法處理的異常:' + str(e)
-                        err_print(self._sn, 'FTP狀態', detail, status=1)
+                        detail = self._video_filename + ' 在連線 FTP 時發生無法處理的異常：' + str(e)
+                        err_print(self._sn, 'FTP 狀態', detail, status=1)
                     break
 
             if not connect_flag:
-                err_print(self._sn, '上傳失败', self._video_filename, status=1)
-                return connect_flag  # 如果连接失败, 直接放弃
+                err_print(self._sn, '上傳失敗', self._video_filename, status=1)
+                return connect_flag  # 如果連線失敗，直接放棄
 
-            ftp.voidcmd('TYPE I')  # 二进制模式
+            ftp.voidcmd('TYPE I')  # 二進位制模式
 
             if self._settings['ftp']['cwd']:
                 try:
-                    ftp.cwd(self._settings['ftp']['cwd'])  # 进入用户指定目录
+                    ftp.cwd(self._settings['ftp']['cwd'])  # 進入使用者指定目錄
                 except ftplib.error_perm as e:
                     if show_err:
-                        err_print(self._sn, 'FTP狀態', '進入指定FTP目錄時出錯: ' + str(e), status=1)
+                        err_print(self._sn, 'FT P狀態', '進入指定 FTP 目錄時出錯: ' + str(e), status=1)
 
-            if bangumi_tag:  # 番剧分类
+            if bangumi_tag:  # 番劇分類
                 try:
                     ftp.cwd(bangumi_tag)
                 except ftplib.error_perm:
@@ -1027,10 +1027,10 @@ class Anime:
                         ftp.cwd(bangumi_tag)
                     except ftplib.error_perm as e:
                         if show_err:
-                            err_print(self._sn, 'FTP狀態', '創建目錄番劇目錄時發生異常, 你可能沒有權限創建目錄: ' + str(e), status=1)
+                            err_print(self._sn, 'FTP 狀態', '創建目錄番劇目錄時發生異常，你可能沒有權限創建目錄：' + str(e), status=1)
 
-            # 归类番剧
-            ftp_bangumi_dir = Config.legalize_filename(self._bangumi_name)  # 保证合法
+            # 歸類番劇
+            ftp_bangumi_dir = Config.legalize_filename(self._bangumi_name)  # 保證合法
             try:
                 ftp.cwd(ftp_bangumi_dir)
             except ftplib.error_perm:
@@ -1039,19 +1039,19 @@ class Anime:
                     ftp.cwd(ftp_bangumi_dir)
                 except ftplib.error_perm as e:
                     if show_err:
-                        detail = '你可能沒有權限創建目錄(用於分類番劇), 視頻文件將會直接上傳, 收到異常: ' + str(e)
-                        err_print(self._sn, 'FTP狀態', detail, status=1)
+                        detail = '你可能沒有權限創建目錄（用於分類番劇），影片文件將會直接上傳，收到異常：' + str(e)
+                        err_print(self._sn, 'FTP 狀態', detail, status=1)
 
-            # 删除旧的临时文件夹
+            # 刪除舊的臨時資料夾
             nonlocal first_connect
-            if first_connect:  # 首次连接
+            if first_connect:  # 首次連線
                 remove_dir(tmp_dir)
-                first_connect = False  # 标记第一次连接已完成
+                first_connect = False  # 標記第一次連線已完成
 
-            # 创建新的临时文件夹
-            # 创建临时文件夹是因为 pure-ftpd 在续传时会将文件名更改成不可预测的名字
-            # 正常中斷传输会把名字改回来, 但是意外掉线不会, 为了处理这种情况
-            # 需要获取 pure-ftpd 未知文件名的续传缓存文件, 为了不和其他视频的缓存文件混淆, 故建立一个临时文件夹
+            # 建立新的臨時資料夾
+            # 建立臨時資料夾是因為 pure-ftpd 在續傳時會將檔名更改成不可預測的名字
+            # 正常中斷傳輸會把名字改回來, 但是意外掉線不會, 為了處理這種情況
+            # 需要獲取 pure-ftpd 未知檔名的續傳快取檔案, 為了不和其他影片的快取檔案混淆, 故建立一個臨時資料夾
             try:
                 ftp.cwd(tmp_dir)
             except ftplib.error_perm:
@@ -1065,7 +1065,7 @@ class Anime:
                 ftp.quit()
             except BaseException as e:
                 if show_err and self._settings['ftp']['show_error_detail']:
-                    err_print(self._sn, 'FTP狀態', '將强制關閉FTP連接, 因爲在退出時收到異常: ' + str(e))
+                    err_print(self._sn, 'FTP 狀態', '將强制關閉 FTP 連接，因爲在退出時收到異常：' + str(e))
                 ftp.close()
 
         def remove_dir(dir_name):
@@ -1073,15 +1073,15 @@ class Anime:
                 ftp.rmd(dir_name)
             except ftplib.error_perm as e:
                 if 'Directory not empty' in str(e):
-                    # 如果目录非空, 则删除内部文件
+                    # 如果目錄非空，則刪除內部檔案
                     ftp.cwd(dir_name)
                     del_all_files()
                     ftp.cwd('..')
-                    ftp.rmd(dir_name)  # 删完内部文件, 删除文件夹
+                    ftp.rmd(dir_name)  # 刪完內部檔案，刪除資料夾
                 elif 'No such file or directory' in str(e):
                     pass
                 else:
-                    # 其他非空目录报错
+                    # 其他非空目錄報錯
                     raise e
 
         def del_all_files():
@@ -1089,135 +1089,135 @@ class Anime:
                 for file_need_del in ftp.nlst():
                     if not re.match(r'^(\.|\.\.)$', file_need_del):
                         ftp.delete(file_need_del)
-                        # print('删除了文件: ' + file_need_del)
+                        # print('刪除了檔案: ' + file_need_del)
             except ftplib.error_perm as resp:
                 if not str(resp) == "550 No files found":
                     raise
 
-        if not connect_ftp():  # 连接 FTP
-            return self.upload_succeed_flag  # 如果连接失败
+        if not connect_ftp():  # 連線 FTP
+            return self.upload_succeed_flag  # 如果連線失敗
 
         err_print(self._sn, '正在上傳', self._video_filename + ' title=' + self._title + '……')
         try_counter = 0
-        video_filename = self._video_filename  # video_filename 将可能会储存 pure-ftpd 缓存文件名
+        video_filename = self._video_filename  # video_filename 將可能會儲存 pure-ftpd 快取檔名
         max_try_num = self._settings['ftp']['max_retry_num']
-        local_size = os.path.getsize(self.local_video_path)  # 本地文件大小
+        local_size = os.path.getsize(self.local_video_path)  # 本地檔案大小
         while try_counter <= max_try_num:
             try:
                 if try_counter > 0:
-                    # 传输遭中断后处理
-                    detail = self._video_filename + ' 发生异常, 重連FTP, 續傳文件, 將重試最多' + str(max_try_num) + '次……'
+                    # 傳輸遭中斷後處理
+                    detail = self._video_filename + ' 發生異常，重連 FTP，續傳檔案，將重試最多' + str(max_try_num) + '次……'
                     err_print(self._sn, '上傳狀態', detail, status=1)
-                    if not connect_ftp():  # 重连
+                    if not connect_ftp():  # 重連
                         return self.upload_succeed_flag
 
-                    # 解决操蛋的 Pure-Ftpd 续传一次就改名导致不能再续传问题.
-                    # 一般正常关闭文件传输 Pure-Ftpd 会把名字改回来, 但是遇到网络意外中断, 那么就不会改回文件名, 留着临时文件名
-                    # 本段就是处理这种情况
+                    # 解決操蛋的 Pure-Ftpd 續傳一次就改名導致不能再續傳問題。
+                    # 一般正常關閉檔案傳輸 Pure-Ftpd 會把名字改回來，但是遇到網路意外中斷，那麼就不會改回檔名，留著臨時檔名
+                    # 本段就是處理這種情況
                     try:
                         for i in ftp.nlst():
                             if 'pureftpd-upload' in i:
-                                # 找到 pure-ftpd 缓存, 直接抓缓存来续传
+                                # 找到 pure-ftpd 快取，直接抓快取來續傳
                                 video_filename = i
                     except ftplib.error_perm as resp:
-                        if not str(resp) == "550 No files found":  # 非文件不存在错误, 抛出异常
+                        if not str(resp) == "550 No files found":  # 非檔案不存在錯誤，丟擲異常
                             raise
-                # 断点续传
+                # 斷點續傳
                 try:
-                    # 需要 FTP Server 支持续传
-                    ftp_binary_size = ftp.size(video_filename)  # 远程文件字节数
+                    # 需要 FTP Server 支援續傳
+                    ftp_binary_size = ftp.size(video_filename)  # 遠端檔案位元組數
                 except ftplib.error_perm:
-                    # 如果不存在文件
+                    # 如果不存在檔案
                     ftp_binary_size = 0
                 except OSError:
                     try_counter = try_counter + 1
                     continue
 
-                ftp.voidcmd('TYPE I')  # 二进制模式
-                conn = ftp.transfercmd('STOR ' + video_filename, ftp_binary_size)  # ftp服务器文件名和offset偏移地址
+                ftp.voidcmd('TYPE I')  # 二進位制模式
+                conn = ftp.transfercmd('STOR ' + video_filename, ftp_binary_size)  # ftp 伺服器檔名和 offset 偏移地址
                 with open(self.local_video_path, 'rb') as f:
-                    f.seek(ftp_binary_size)  # 从断点处开始读取
+                    f.seek(ftp_binary_size)  # 從斷點處開始讀取
                     while True:
-                        block = f.read(1048576)  # 读取1M
+                        block = f.read(1048576)  # 讀取 1M
                         conn.sendall(block)  # 送出 block
                         if not block:
-                            time.sleep(3)  # 等待一下, 让sendall()完成
+                            time.sleep(3)  # 等待一下，等待 sendall() 完成
                             break
 
                 conn.close()
 
-                err_print(self._sn, '上傳狀態', '檢查遠端文件大小是否與本地一致……')
+                err_print(self._sn, '上傳狀態', '檢查遠端檔案大小是否與本地一致……')
                 exit_ftp(False)
                 connect_ftp(False)
-                # 不重连的话, 下面查询远程文件大小会返回 None, 懵逼...
-                # sendall()没有完成将会 500 Unknown command
+                # 不重連的話, 下面查詢遠端檔案大小會返回 None, 懵逼...
+                # sendall()沒有完成將會 500 Unknown command
                 err_counter = 0
                 remote_size = 0
                 while err_counter < 3:
                     try:
-                        remote_size = ftp.size(video_filename)  # 远程文件大小
+                        remote_size = ftp.size(video_filename)  # 遠端檔案大小
                         break
                     except ftplib.error_perm as e1:
-                        err_print(self._sn, 'FTP狀態', 'ftplib.error_perm: ' + str(e1))
+                        err_print(self._sn, 'FTP 狀態', 'ftplib.error_perm: ' + str(e1))
                         remote_size = 0
                         break
                     except OSError as e2:
-                        err_print(self._sn, 'FTP狀態', 'OSError: ' + str(e2))
+                        err_print(self._sn, 'FTP 狀態', 'OSError: ' + str(e2))
                         remote_size = 0
-                        connect_ftp(False)  # 掉线重连
+                        connect_ftp(False)  # 斷線重連
                         err_counter = err_counter + 1
 
                 if remote_size is None:
-                    err_print(self._sn, 'FTP狀態', 'remote_size is None')
+                    err_print(self._sn, 'FTP 狀態', 'remote_size is None')
                     remote_size = 0
-                # 远程文件大小获取失败, 可能文件不存在或者抽风
-                # 那上面获取远程字节数将会是0, 导致重新下载, 那么此时应该清空缓存目录下的文件
-                # 避免后续找错文件续传
+                # 遠端檔案大小獲取失敗, 可能檔案不存在或者抽風
+                # 那上面獲取遠端位元組數將會是0, 導致重新下載, 那麼此時應該清空快取目錄下的檔案
+                # 避免後續找錯檔案續傳
                 if remote_size == 0:
                     del_all_files()
 
                 if remote_size != local_size:
-                    # 如果远程文件大小与本地不一致
+                    # 如果遠端檔案大小與本地不一致
                     # print('remote_size='+str(remote_size))
                     # print('local_size ='+str(local_size))
                     detail = self._video_filename + ' 在遠端為' + str(
                         round(remote_size / float(1024 * 1024), 2)) + 'MB' + ' 與本地' + str(
-                        round(local_size / float(1024 * 1024), 2)) + 'MB 不一致! 將重試最多' + str(max_try_num) + '次'
+                        round(local_size / float(1024 * 1024), 2)) + 'MB 不一致！將重試最多' + str(max_try_num) + '次'
                     err_print(self._sn, '上傳狀態', detail, status=1)
                     try_counter = try_counter + 1
-                    continue  # 续传
+                    continue  # 續傳
 
-                # 顺利上传完后
-                ftp.cwd('..')  # 返回上级目录, 即退出临时目录
+                # 順利上傳後
+                ftp.cwd('..')  # 返回上級目錄，即退出臨時目錄
                 try:
-                    # 如果同名文件存在, 则删除
+                    # 如果同名檔案存在，則刪除
                     ftp.size(self._video_filename)
                     ftp.delete(self._video_filename)
                 except ftplib.error_perm:
                     pass
-                ftp.rename(tmp_dir + '/' + video_filename, self._video_filename)  # 将视频从临时文件移出, 顺便重命名
-                remove_dir(tmp_dir)  # 删除临时目录
-                self.upload_succeed_flag = True  # 标记上传成功
+                ftp.rename(tmp_dir + '/' + video_filename, self._video_filename)  # 將影片從臨時檔案移出, 順便重新命名
+                remove_dir(tmp_dir)  # 刪除臨時目錄
+                self.upload_succeed_flag = True  # 標記上傳成功
                 break
 
             except ConnectionResetError as e:
                 if self._settings['ftp']['show_error_detail']:
-                    detail = self._video_filename + ' 在上傳過程中網絡被重置, 將重試最多' + str(max_try_num) + '次' + ', 收到異常: ' + str(e)
+                    detail = self._video_filename + ' 在上傳過程中網絡被重置，將重試最多' + str(max_try_num) + '次' + ', 收到異常：' + str(e)
                     err_print(self._sn, '上傳狀態', detail, status=1)
                 try_counter = try_counter + 1
             except TimeoutError as e:
                 if self._settings['ftp']['show_error_detail']:
-                    detail = self._video_filename + ' 在上傳過程中超時, 將重試最多' + str(max_try_num) + '次, 收到異常: ' + str(e)
+                    detail = self._video_filename + ' 在上傳過程中超時，將重試最多' + str(max_try_num) + '次，收到異常：' + str(e)
                     err_print(self._sn, '上傳狀態', detail, status=1)
                 try_counter = try_counter + 1
             except socket.timeout as e:
                 if self._settings['ftp']['show_error_detail']:
-                    detail = self._video_filename + ' 在上傳過程socket超時, 將重試最多' + str(max_try_num) + '次, 收到異常: ' + str(e)
+                    detail = self._video_filename + ' 在上傳過程 socket 超時，將重試最多' + str(max_try_num) + '次，收到異常：' + str(e)
                     err_print(self._sn, '上傳狀態', detail, status=1)
                 try_counter = try_counter + 1
 
         if not self.upload_succeed_flag:
-            err_print(self._sn, '上傳失敗', self._video_filename + ' 放棄上傳!', status=1)
+            err_print(self._sn, '上傳失敗', self._video_filename + ' 放棄上傳！', status=1)
             exit_ftp()
             return self.upload_succeed_flag
 

--- a/ColorPrint.py
+++ b/ColorPrint.py
@@ -15,17 +15,17 @@ def read_log_settings():
     settings = {}
     try:
         with open(Config.get_config_path(), 'r', encoding='utf-8') as f:
-            # 转义win路径
+            # 轉譯 win 路徑
             settings = json.loads(re.sub(r'\\', '\\\\\\\\', f.read()))
     except json.JSONDecodeError:
-        Config.del_bom(Config.get_config_path(), display=False)  # 移除bom
-        # 重新载入
+        Config.del_bom(Config.get_config_path(), display=False)  # 移除 bom
+        # 重新載入
         with open(Config.get_config_path(), 'r', encoding='utf-8') as f:
             settings = json.loads(re.sub(r'\\', '\\\\\\\\', f.read()))
     except BaseException as e:
         settings['save_logs'] = True
         settings['quantity_of_logs'] = 7
-        print('日志配置讀取失敗, 將使用默認配置: 啓用日志, 最多保存7份 '+str(e))
+        print('日誌設定讀取失敗，將使用預設設定：啟用日誌，最多儲存7份 '+str(e))
     if 'save_logs' not in settings.keys():
         settings['save_logs'] = True
     if 'quantity_of_logs' not in settings.keys():
@@ -37,12 +37,12 @@ log_settings = read_log_settings()
 
 
 def err_print(sn, err_msg, detail='', status=0, no_sn=False, prefix='', display=True, display_time=True):
-    # status 三个设定值, 0 为一般输出, 1 为错误输出, 2 为成功输出
-    # err_msg 为信息类型/概要, 最好为四字中文
-    # detail 为详细信息描述
-    # no_sn 控制是否打印 sn , 默认打印
-    # 格式范例:
-    # 2019-01-30 17:22:30 更新狀態: sn=12345 檢查更新失敗, 跳過等待下次檢查
+    # status 三個設定值：0 為一般輸出、1 為錯誤輸出、2 為成功輸出
+    # err_msg 為資訊型別/概要，最好為四字中文
+    # detail 為詳細資訊描述
+    # no_sn 控制是否列印 sn，預設列印
+    # 格式範例：
+    # 2019-01-30 17:22:30 更新狀態：sn=12345 檢查更新失敗，跳過等待下次檢查
     green = False
 
     def succeed_or_failed_print():
@@ -74,11 +74,11 @@ def err_print(sn, err_msg, detail='', status=0, no_sn=False, prefix='', display=
         if status == 0:
             print(msg)
         elif status == 1:
-            # 为 1 错误输出
+            # 為 1 錯誤輸出
             green = False
             succeed_or_failed_print()
         else:
-            # 为 2 成功输出
+            # 為 2 成功輸出
             green = True
             succeed_or_failed_print()
 
@@ -91,7 +91,7 @@ def err_print(sn, err_msg, detail='', status=0, no_sn=False, prefix='', display=
             log.write(msg + '\n')
 
 
-# 用於Win下染色輸出，代碼來自 https://blog.csdn.net/five3/article/details/7630295
+# 用於Win下染色輸出，程式碼來自 https://blog.csdn.net/five3/article/details/7630295
 class Color:
     ''' See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/winprog/winprog/windows_api_reference.asp
     for information on Windows APIs.'''

--- a/Config.py
+++ b/Config.py
@@ -128,6 +128,10 @@ def __init_settings():
                 'telebot_token': "",
                 'discord_notify': False,
                 'discord_token': '',
+                'plex_refresh': False,
+                'plex_url': '',
+                'plex_token': '',
+                'plex_section': '',
                 'faststart_movflags': False,
                 'audio_language': False,
                 'use_mobile_api': False,
@@ -257,6 +261,13 @@ def __update_settings(old_settings):  # 升级配置文件
         # 新增推送通知到TG的功能
         new_settings['discord_notify'] = False
         new_settings['discord_token'] = ''
+
+    if 'plex_refresh' not in new_settings.keys():
+        # 新增 plex 自動更新
+        new_settings['plex_refresh'] = False
+        new_settings['plex_url'] = ''
+        new_settings['plex_token'] = ''
+        new_settings['plex_section'] = ''
 
     if 'faststart_movflags' not in new_settings.keys():
         # v9.0 新增功能: 将 metadata 移至视频文件头部

--- a/Config.py
+++ b/Config.py
@@ -27,13 +27,13 @@ latest_database_version = 2.0
 cookie = None
 max_multi_thread = 5
 max_multi_downloading_segment = 5
-tasks_progress_rate = {}  # 储存任务进度, 供面板使用,
-# 格式: {sn: {'rate': 任务进度百分比(float), 'status': 任务状态, 'filename': 文件名} }
-# 任务状态有:  '正在下載' '正在解密合并' '正在移至番劇目錄' '任務失敗, 等待重啓' '等待下載'
+tasks_progress_rate = {}  # 儲存任務進度，供面板使用，
+# 格式: {sn: {'rate': 任務進度百分比(float), 'status': 任務狀態, 'filename': 檔名} }
+# 任務狀態有:  '正在下載' '正在解密合並' '正在移至番劇目錄' '任務失敗, 等待重啟' '等待下載'
 
 
 def __color_print(sn, err_msg, detail='', status=0, no_sn=False, display=True):
-    # 避免与 ColorPrint.py 相互调用产生问题
+    # 避免與 ColorPrint.py 相互呼叫產生問題
     try:
         err_print(sn, err_msg, detail=detail, status=status, no_sn=no_sn, display=display)
     except UnboundLocalError:
@@ -46,16 +46,16 @@ def get_max_multi_thread():
 
 
 def legalize_filename(filename):
-    # 文件名合法化
-    legal_filename = re.sub(r'\|+', '｜', filename)  # 处理 | , 转全型｜
-    legal_filename = re.sub(r'\?+', '？', legal_filename)  # 处理 ? , 转中文 ？
-    legal_filename = re.sub(r'\*+', '＊', legal_filename)  # 处理 * , 转全型＊
-    legal_filename = re.sub(r'<+', '＜', legal_filename)  # 处理 < , 转全型＜
-    legal_filename = re.sub(r'>+', '＞', legal_filename)  # 处理 < , 转全型＞
-    legal_filename = re.sub(r'\"+', '＂', legal_filename)  # 处理 " , 转全型＂
-    legal_filename = re.sub(r':+', '：', legal_filename)  # 处理 : , 转中文：
-    legal_filename = re.sub(r'\\', '＼', legal_filename)  # 处理 \ , 转全型＼
-    legal_filename = re.sub(r'/', '／', legal_filename)  # 处理 / , 转全型／
+    # 檔名合法化
+    legal_filename = re.sub(r'\|+', '｜', filename)  # 處理 | , 轉全型｜
+    legal_filename = re.sub(r'\?+', '？', legal_filename)  # 處理 ? , 轉中文 ？
+    legal_filename = re.sub(r'\*+', '＊', legal_filename)  # 處理 * , 轉全型＊
+    legal_filename = re.sub(r'<+', '＜', legal_filename)  # 處理 < , 轉全型＜
+    legal_filename = re.sub(r'>+', '＞', legal_filename)  # 處理 < , 轉全型＞
+    legal_filename = re.sub(r'\"+', '＂', legal_filename)  # 處理 " , 轉全型＂
+    legal_filename = re.sub(r':+', '：', legal_filename)  # 處理 : , 轉中文：
+    legal_filename = re.sub(r'\\', '＼', legal_filename)  # 處理 \ , 轉全型＼
+    legal_filename = re.sub(r'/', '／', legal_filename)  # 處理 / , 轉全型／
     return legal_filename
 
 
@@ -68,9 +68,9 @@ def get_config_path():
 
 
 def get_sn_list_content():
-    # 返回 sn_list 所有内容, 包括注释, 提供给 Web 控制台
+    # 返回 sn_list 所有內容, 包括註釋, 提供給 Web 控制檯
     if not os.path.exists(sn_list_path):
-        return ""
+        return ''
     with open(sn_list_path, 'r', encoding='utf-8') as f:
         return f.read()
 
@@ -80,37 +80,37 @@ def __init_settings():
         os.remove(config_path)
     settings = {'bangumi_dir': '',
                 'temp_dir': '',
-                'classify_bangumi': True,  # 控制是否建立番剧目录
-                'check_frequency': 5,  # 检查 cd 时间, 单位分钟
-                'download_resolution': '1080',  # 下载分辨率
-                'lock_resolution': False,  # 锁定分辨率, 如果分辨率不存在, 则宣布下载失败
-                'only_use_vip': False,  # 锁定 VIP 账号下载
-                'default_download_mode': 'latest',  # 仅下载最新一集，另一个模式是 'all' 下载所有及日后更新
-                'use_copyfile_method': False,  # 转移视频至番剧目录时是否使用复制法, 使用 True 以兼容 rclone 挂载盘
-                'multi-thread': 1,  # 最大并发下载数
-                'multi_upload': 3,  # 最大并发上传数
-                'segment_download_mode': True,  # 由 aniGamerPlus 下载分段, False 为 ffmpeg 下载
-                'multi_downloading_segment': 2,  # 在上面配置为 True 时有效, 每个视频并发下载分段数
-                'segment_max_retry': 8,  # 在分段下载模式时有效, 每个分段最大重试次数, -1 为 无限重试
+                'classify_bangumi': True,  # 控制是否建立番劇目錄
+                'check_frequency': 5,  # 檢查 cd 時間, 單位分鐘
+                'download_resolution': '1080',  # 下載解析度
+                'lock_resolution': False,  # 鎖定解析度, 如果解析度不存在, 則宣吿下載失敗
+                'only_use_vip': False,  # 鎖定 VIP 帳號下載
+                'default_download_mode': 'latest',  # 僅下載最新一集，另一個模式是 'all' 下載所有及日後更新
+                'use_copyfile_method': False,  # 轉移影片至番劇目錄時是否使用複製法, 使用 True 以相容 rclone 掛載硬碟
+                'multi-thread': 1,  # 最大併發下載數
+                'multi_upload': 3,  # 最大併發上傳數
+                'segment_download_mode': True,  # 由 aniGamerPlus 下載分段, False 為 ffmpeg 下載
+                'multi_downloading_segment': 2,  # 在上面設定為 True 時有效, 每個影片併發下載分段數
+                'segment_max_retry': 8,  # 在分段下載模式時有效, 每個分段最大重試次數, -1 為 無限重試
                 'add_bangumi_name_to_video_filename': True,
-                'add_resolution_to_video_filename': True,  # 是否在文件名中添加清晰度说明
-                'customized_video_filename_prefix': '【動畫瘋】',  # 用户自定前缀
-                'customized_bangumi_name_suffix': '',  # 用户自定义番剧名后缀 (在剧集名之前)
-                'customized_video_filename_suffix': '',  # 用户自定后缀
-                'video_filename_extension': 'mp4',  # 视频扩展名/封装格式
-                'zerofill': 1,  # 剧集名补零, 此项填补足位数, 小于等于 1 即不补零
-                # cookie的自动刷新对 UA 有检查
-                'ua': "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Safari/537.36",
+                'add_resolution_to_video_filename': True,  # 是否在檔名中新增解析度說明
+                'customized_video_filename_prefix': '【動畫瘋】',  # 使用者自定字首
+                'customized_bangumi_name_suffix': '',  # 使用者自定義番劇名字尾 (在劇集名之前)
+                'customized_video_filename_suffix': '',  # 使用者自定字尾
+                'video_filename_extension': 'mp4',  # 影片副檔名/封裝格式
+                'zerofill': 1,  # 劇集名補零, 此項填補足位數, 小於等於 1 即不補零
+                # cookie 的自動重新整理對 UA 有檢查
+                'ua': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Safari/537.36',
                 'use_proxy': False,
-                'proxy': 'http://user:passwd@example.com:1000',  # 代理功能, config_version v13.0 删除链式代理
+                'proxy': 'http://user:passwd@example.com:1000',  # 代理功能，config_version v13.0 刪除鏈式代理
                 'upload_to_server': False,
-                'ftp': {  # 将文件上传至远程服务器
+                'ftp': {  # 將檔案上傳至遠端伺服器
                     'server': '',
                     'port': '',
                     'user': '',
                     'pwd': '',
                     'tls': True,
-                    'cwd': '',  # 文件存放目录, 登陆后首先进入的目录
+                    'cwd': '',  # 檔案存放目錄，登入後首先進入的目錄
                     'show_error_detail': False,
                     'max_retry_num': 15
                 },
@@ -125,7 +125,7 @@ def __init_settings():
                     ]
                 },
                 'telebot_notify': False,
-                'telebot_token': "",
+                'telebot_token': '',
                 'discord_notify': False,
                 'discord_token': '',
                 'plex_refresh': False,
@@ -136,11 +136,11 @@ def __init_settings():
                 'audio_language': False,
                 'use_mobile_api': False,
                 'danmu': False,
-                'check_latest_version': True,  # 是否检查新版本
+                'check_latest_version': True,  # 是否檢查新版本
                 'read_sn_list_when_checking_update': True,
                 'read_config_when_checking_update': True,
                 'ads_time': 25,
-                "mobile_ads_time": 3,
+                'mobile_ads_time': 3,
                 'use_dashboard': True,
                 'dashboard': {
                     'host': '127.0.0.1',
@@ -159,87 +159,87 @@ def __init_settings():
         json.dump(settings, f, ensure_ascii=False, indent=4)
 
 
-def __update_settings(old_settings):  # 升级配置文件
+def __update_settings(old_settings):  # 升級設定檔案
     new_settings = old_settings.copy()
-    if 'check_latest_version' not in new_settings.keys():  # v2.0 新增检查更新开关
+    if 'check_latest_version' not in new_settings.keys():  # v2.0 新增檢查更新開關
         new_settings['check_latest_version'] = True
 
-    if 'tls' not in new_settings['ftp'].keys():  # v2.0 新增 FTP over TLS 开关
+    if 'tls' not in new_settings['ftp'].keys():  # v2.0 新增 FTP over TLS 開關
         new_settings['ftp']['tls'] = True
 
-    if 'upload_to_server' not in new_settings.keys():  # v2.0 新增上传开关
+    if 'upload_to_server' not in new_settings.keys():  # v2.0 新增上傳開關
         new_settings['upload_to_server'] = False
 
-    if 'use_proxy' not in new_settings.keys():  # v2.0 新增代理开关
+    if 'use_proxy' not in new_settings.keys():  # v2.0 新增代理開關
         new_settings['use_proxy'] = False
 
-    if 'show_error_detail' not in new_settings['ftp'].keys():  # v2.0 新增显示FTP传输错误开关
+    if 'show_error_detail' not in new_settings['ftp'].keys():  # v2.0 新增顯示 FTP 傳輸錯誤開關
         new_settings['ftp']['show_error_detail'] = False
 
-    if 'max_retry_num' not in new_settings['ftp'].keys():  # v2.0 新增显示FTP重传尝试数
+    if 'max_retry_num' not in new_settings['ftp'].keys():  # v2.0 新增顯示 FTP 重傳嘗試數
         new_settings['ftp']['max_retry_num'] = 10
 
-    if 'read_sn_list_when_checking_update' not in new_settings.keys():  # v2.0 新增开关: 每次检查更新时读取sn_list
+    if 'read_sn_list_when_checking_update' not in new_settings.keys():  # v2.0 新增開關：每次檢查更新時讀取s n_list
         new_settings['read_sn_list_when_checking_update'] = True
 
-    if 'multi_upload' not in new_settings.keys():  # v2.0 新增最大并行上传任务数
+    if 'multi_upload' not in new_settings.keys():  # v2.0 新增最大並行上傳任務數
         new_settings['multi_upload'] = 3
 
-    if 'read_config_when_checking_update' not in new_settings.keys():  # v2.0 新增开关: 每次检查更新时读取config.json
+    if 'read_config_when_checking_update' not in new_settings.keys():  # v2.0 新增開關：每次檢查更新時讀取 config.json
         new_settings['read_config_when_checking_update'] = True
 
-    if 'add_bangumi_name_to_video_filename' not in new_settings.keys():  # v3.0 新增开关, 文件名可以单纯用剧集命名
+    if 'add_bangumi_name_to_video_filename' not in new_settings.keys():  # v3.0 新增開關，檔名可以單純用劇集命名
         new_settings['add_bangumi_name_to_video_filename'] = True
 
-    if 'segment_download_mode' not in new_settings.keys():  # v3.1 新增分段下载模式开关
+    if 'segment_download_mode' not in new_settings.keys():  # v3.1 新增分段下載模式開關
         new_settings['segment_download_mode'] = True
 
-    if 'multi_downloading_segment' not in new_settings.keys():  # v3.1 新增分段下载模式下每个视频并发下载分段数
+    if 'multi_downloading_segment' not in new_settings.keys():  # v3.1 新增分段下載模式下每個影片併發下載分段數
         new_settings['multi_downloading_segment'] = 2
 
-    new_settings['database_version'] = latest_database_version  # v3.2 新增数据库版本号
+    new_settings['database_version'] = latest_database_version  # v3.2 新增資料庫版本號
 
-    if 'save_logs' not in new_settings.keys():  # v4.0 新增日志开关
+    if 'save_logs' not in new_settings.keys():  # v4.0 新增日誌開關
         new_settings['save_logs'] = True
 
-    if 'quantity_of_logs' not in new_settings.keys():  # v4.0 新增日志数量配置(一天一日志)
+    if 'quantity_of_logs' not in new_settings.keys():  # v4.0 新增日誌數量設定（一天一日誌）
         new_settings['quantity_of_logs'] = 7
 
-    if 'temp_dir' not in new_settings.keys():  # v4.0 新增缓存目录选项
+    if 'temp_dir' not in new_settings.keys():  # v4.0 新增快取目錄選項
         new_settings['temp_dir'] = ''
 
     if 'lock_resolution' not in new_settings.keys():
-        new_settings['lock_resolution'] = False  # v4.1 新增分辨率锁定开关
+        new_settings['lock_resolution'] = False  # v4.1 新增解析度鎖定開關
 
-    if 'ua' not in new_settings.keys():  # v4.2 新增 UA 配置
-        new_settings['ua'] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Safari/537.36"
+    if 'ua' not in new_settings.keys():  # v4.2 新增 UA 設定
+        new_settings['ua'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Safari/537.36'
 
     if 'classify_bangumi' not in new_settings.keys():
-        new_settings['classify_bangumi'] = True  # v5.0 新增是否建立番剧目录开关
+        new_settings['classify_bangumi'] = True  # v5.0 新增是否建立番劇目錄開關
 
     if 'use_copyfile_method' not in new_settings.keys():
-        # v6.0 新增视频转移方法开关, 配置 True 以适配 rclone 挂载盘
+        # v6.0 新增影片轉移方法開關，設定 True 以配合 rclone 掛載
         new_settings['use_copyfile_method'] = False
 
     if 'zerofill' not in new_settings.keys():
-        # v6.0 新增剧集名补零, 该项数字为补足位数, 默认为 1, 小于等于 1 即不补 0
+        # v6.0 新增劇集名補零，該項數字為補足位數，預設為 1，小於等於 1 即不補 0
         new_settings['zerofill'] = 1
 
     if 'customized_bangumi_name_suffix' not in new_settings.keys():
-        # v7.0 新增自定义番剧名后缀
+        # v7.0 新增自定義番劇名字尾
         new_settings['customized_bangumi_name_suffix'] = ''
 
     if 'user_command' not in new_settings.keys():
-        # v8.0 新增命令行模式完成后, 执行自定义命令
-        # 默认命令为一分钟后关机
+        # v8.0 新增命令列模式完成後，執行自定義命令
+        # 預設命令為一分鐘後關機
         new_settings['user_command'] = 'shutdown -s -t 60'
 
     if 'segment_download_max_retry' not in new_settings.keys():
-        # v9.0 新增分段模式下, 分段重试次数
+        # v9.0 新增分段模式下，分段重試次數
         new_settings['segment_max_retry'] = 8
 
     if 'coolq_notify' not in new_settings.keys():
-        # v9.0 新增推送通知到CQ的功能
+        # v9.0 新增推送通知到 CQ 的功能
         new_settings['coolq_notify'] = False
         new_settings['coolq_settings'] = {
             'host': '127.0.0.1',
@@ -249,16 +249,16 @@ def __update_settings(old_settings):  # 升级配置文件
             'query': {
                 'group_id': '123456789',
             },
-            "user_message": ""
+            'user_message': ''
         }
 
     if 'telebot_notify' not in new_settings.keys():
-        # 新增推送通知到TG的功能
+        # 新增推送通知到 TG 的功能
         new_settings['telebot_notify'] = False
-        new_settings['telebot_token'] = ""
+        new_settings['telebot_token'] = '1'
 
     if 'discord_notify' not in new_settings.keys():
-        # 新增推送通知到TG的功能
+        # 新增推送通知到 Discord 的功能
         new_settings['discord_notify'] = False
         new_settings['discord_token'] = ''
 
@@ -270,32 +270,32 @@ def __update_settings(old_settings):  # 升级配置文件
         new_settings['plex_section'] = ''
 
     if 'faststart_movflags' not in new_settings.keys():
-        # v9.0 新增功能: 将 metadata 移至视频文件头部
-        # 此功能可以更快的在线播放视频
+        # v9.0 新增功能：將 metadata 移至影片檔案頭部
+        # 此功能可以更快的線上播放影片
         new_settings['faststart_movflags'] = False
 
     if 'video_filename_extension' not in new_settings.keys():
-        # v17 新增用户自定义视频扩展名
+        # v17 新增使用者自定義影片副檔名
         new_settings['video_filename_extension'] = 'mp4'
 
     if 'audio_language' not in new_settings.keys():
-        # v19 添加音轨日语标签  #37
+        # v19 新增音軌日語標籤  #37
         new_settings['audio_language'] = False
 
     if 'audio_language_jpn' in new_settings.keys():
         del new_settings['audio_language_jpn']
 
     if 'proxy' not in new_settings.keys() or 'proxies' in new_settings.keys():
-        # v20 删除链式代理功能
-        if new_settings['proxies']["1"]:
-            # 转移用户原有配置
-            new_settings['proxy'] = new_settings['proxies']["1"]
+        # v20 刪除鏈式代理功能
+        if new_settings['proxies']['1']:
+            # 轉移使用者原有設定
+            new_settings['proxy'] = new_settings['proxies']['1']
         else:
             new_settings['proxy'] = 'http://user:passwd@example.com:1000'
         del new_settings['proxies']
 
     if 'use_dashboard' not in new_settings.keys():
-        # v20 上线 Web 控制台
+        # v20 上線 Web 控制檯
         new_settings['use_dashboard'] = True
 
     if 'dashboard' not in new_settings.keys():
@@ -312,32 +312,32 @@ def __update_settings(old_settings):  # 升级配置文件
         new_settings['ads_time'] = 25
 
     if 'danmu' not in new_settings.keys():
-        # 支持下载弹幕
+        # 支援下載彈幕
         # https://github.com/miyouzi/aniGamerPlus/pull/66
         new_settings['danmu'] = False
 
     if 'use_mobile_api' not in new_settings.keys():
-        # v21.0 新增使用APP API #69
+        # v21.0 新增使用 APP API #69
         new_settings['use_mobile_api'] = False
 
     if 'mobile_ads_time' not in new_settings.keys():
-        new_settings['mobile_ads_time'] = 3  # 使用APP API非会员广告等待时间可低至 3s
+        new_settings['mobile_ads_time'] = 3  # 使用APP API 非會員廣告等待時間可低至 3s
 
     if 'message_suffix' not in new_settings['coolq_settings'].keys():
         # v21.1 新增
-        new_settings['coolq_settings']['message_suffix'] = "追加的資訊"
+        new_settings['coolq_settings']['message_suffix'] = '追加的資訊'
 
     if 'user_message' in new_settings['coolq_settings'].keys():
-        # QQ机器人推送通知可以通过配置追加通知内容
+        # QQ 機器人推送通知可以透過設定追加通知內容
         new_settings['coolq_settings']['message_suffix'] = new_settings['coolq_settings']['user_message']
         del new_settings['coolq_settings']['user_message']
 
     if 'msg_argument_name' not in new_settings['coolq_settings'].keys():
-        # v21.1 让用户自行构造QQ机器人 URL
-        new_settings['coolq_settings']['msg_argument_name'] = "message"
+        # v21.1 讓使用者自行構造 QQ 機器人 URL
+        new_settings['coolq_settings']['msg_argument_name'] = 'message'
 
     if 'SSL' in new_settings['coolq_settings'].keys():
-        # 继承用户配置
+        # 繼承使用者設定
         if new_settings['coolq_settings']['SSL']:
             req = 'https://'
         else:
@@ -357,7 +357,7 @@ def __update_settings(old_settings):  # 升级配置文件
     new_settings['config_version'] = latest_config_version
     with open(config_path, 'w', encoding='utf-8') as f:
         json.dump(new_settings, f, ensure_ascii=False, indent=4)
-    msg = '配置文件從 v' + str(old_settings['config_version']) + ' 升級到 v' + str(latest_config_version) + ' 你的有效配置不會丟失!'
+    msg = '設定檔案從 v' + str(old_settings['config_version']) + ' 升級到 v' + str(latest_config_version) + ' 你的有效設定檔不會遺失！'
     __color_print(0, msg, status=2, no_sn=True)
 
 
@@ -383,21 +383,21 @@ def __update_database(old_version):
         cursor.execute('SELECT COUNT(*) FROM anime')
     except sqlite3.OperationalError as e:
         if 'no such table' in str(e):
-            # 如果不存在表, 则新建
+            # 如果不存在表，則新建
             creat_table()
 
     try:
         cursor.execute('SELECT COUNT(local_file_path) FROM anime')
     except sqlite3.OperationalError as e:
         if 'no such column' in str(e):
-            # 更早期的数据库没有 local_file_path , 做兼容
+            # 更早期的資料庫沒有 local_file_path，做相容
             cursor.execute('ALTER TABLE anime ADD local_file_path VARCHAR(500)')
 
     try:
         cursor.execute('SELECT COUNT(sn) FROM anime')
     except sqlite3.OperationalError as e:
         if 'no such column' in str(e):
-            # 数据库 v2.0  将 ns 列改名为 sn
+            # 資料庫 v2.0  將 ns 列改名為 sn
             cursor.execute('ALTER TABLE anime RENAME TO animeOld')
             creat_table()
             cursor.execute("INSERT INTO "
@@ -410,37 +410,37 @@ def __update_database(old_version):
     cursor.close()
     conn.commit()
     conn.close()
-    msg = '資料庫從 v' + str(old_version) + ' 升級到 v' + str(latest_database_version) + ' 内部資料不會丟失'
+    msg = '資料庫從 v' + str(old_version) + ' 升級到 v' + str(latest_database_version) + ' 内部資料不會遺失'
     __color_print(0, msg, status=2, no_sn=True)
 
 
 def __read_settings_file():
     try:
         with open(config_path, 'r', encoding='utf-8') as f:
-            # 转义win路径
+            # 轉譯 win 路徑
             return json.loads(re.sub(r'\\', '\\\\\\\\', f.read()))
     except json.JSONDecodeError:
-        # 如果带有 BOM 头, 则去除
+        # 如果帶有 BOM 頭，則去除
         try:
             # del_bom(config_path)
             check_encoding(config_path)
-            # 重新读取
+            # 重新讀取
             with open(config_path, 'r', encoding='utf-8') as f:
                 return json.loads(re.sub(r'\\', '\\\\\\\\', f.read()))
         except BaseException as e:
-            __color_print(0, '讀取配置發生異常, 將重置配置! ' + str(e), status=1, no_sn=True)
+            __color_print(0, '讀取設定發生異常，將重設設定! ' + str(e), status=1, no_sn=True)
             __init_settings()
             with open(config_path, 'r', encoding='utf-8') as f:
                 return json.load(f)
     except BaseException as e:
-        __color_print(0, '讀取配置發生異常, 將重置配置! ' + str(e), status=1, no_sn=True)
+        __color_print(0, '讀取設定發生異常, 將重置設定！' + str(e), status=1, no_sn=True)
         __init_settings()
         with open(config_path, 'r', encoding='utf-8') as f:
             return json.load(f)
 
 
 def del_bom(path, display=True):
-    # 处理 UTF-8-BOM
+    # 處理 UTF-8-BOM
     have_bom = False
     with open(path, 'rb') as f:
         content = f.read()
@@ -450,7 +450,7 @@ def del_bom(path, display=True):
     if have_bom:
         filename = os.path.split(path)[1]
         if display:
-            __color_print(0, '發現 ' + filename + ' 帶有BOM頭, 將移除后保存', no_sn=True)
+            __color_print(0, '發現 ' + filename + ' 帶有 BOM 頭，將移除後儲存', no_sn=True)
         try_counter = 0
         while True:
             try:
@@ -459,14 +459,14 @@ def del_bom(path, display=True):
             except BaseException as e:
                 if try_counter > 3:
                     if display:
-                        __color_print(0, '無BOM ' + filename + ' 保存失敗! 发生异常: ' + str(e), status=1, no_sn=True)
+                        __color_print(0, '無 BOM ' + filename + ' 儲存失敗！發生異常：' + str(e), status=1, no_sn=True)
                     raise e
                 random_wait_time = random.uniform(2, 5)
                 time.sleep(random_wait_time)
                 try_counter = try_counter + 1
             else:
                 if display:
-                    __color_print(0, '無BOM ' + filename + ' 保存成功', status=2, no_sn=True)
+                    __color_print(0, '無 BOM ' + filename + ' 儲存成功', status=2, no_sn=True)
                 break
 
 
@@ -477,20 +477,20 @@ def read_settings(config=''):
 
         settings = __read_settings_file()
     else:
-        # 用于检查 web 控制台回传的配置是否正确
+        # 用於檢查 web 控制檯回傳的設定是否正確
         settings = config
 
     if 'database_version' in settings.keys():
         if settings['database_version'] < latest_database_version:
             __update_database(settings['database_version'])
     else:
-        # 如果该版本配置下没有 database_version 项, 则数据库版本应该是1.0
+        # 如果該版本設定下沒有 database_version 項，則資料庫版本應該是 1.0
         settings['database_version'] = 1.0
         __update_database(1.0)
 
     if settings['config_version'] < latest_config_version:
-        __update_settings(settings)  # 升级配置
-        settings = __read_settings_file()  # 重新载入
+        __update_settings(settings)  # 升級設定
+        settings = __read_settings_file()  # 重新載入
 
     if settings['ftp']['port']:
         settings['ftp']['port'] = int(settings['ftp']['port'])
@@ -499,30 +499,30 @@ def read_settings(config=''):
     settings['check_frequency'] = int(settings['check_frequency'])
     settings['download_resolution'] = str(settings['download_resolution'])
     settings['multi-thread'] = int(settings['multi-thread'])
-    settings['zerofill'] = int(settings['zerofill'])  # 保证为整数
+    settings['zerofill'] = int(settings['zerofill'])  # 保證為整數
     if not re.match(r'^(all|latest|largest-sn)$', settings['default_download_mode']):
-        settings['default_download_mode'] = 'latest'  # 如果输入非法模式, 将重置为 latest 模式
-    if settings['quantity_of_logs'] < 1:  # 日志数量不可小于 1
+        settings['default_download_mode'] = 'latest'  # 如果輸入非法模式，將重置為 latest 模式
+    if settings['quantity_of_logs'] < 1:  # 日誌數量不可小於 1
         settings['quantity_of_logs'] = 7
 
     if not settings['ua']:
-        # 如果 ua 项目为空
-        settings['ua'] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Safari/537.36"
+        # 如果 ua 選項為空
+        settings['ua'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Safari/537.36'
 
-    # 如果用户自定了番剧目录且存在
+    # 如果使用者自定了番劇目錄且存在
     if settings['bangumi_dir'] and os.path.exists(settings['bangumi_dir']):
-        # 番剧路径规范化
+        # 番劇路徑規範化
         settings['bangumi_dir'] = os.path.abspath(settings['bangumi_dir'])
     else:
-        # 如果用户没有有自定番剧目录或目录不存在，则保存在本地 bangumi 目录
+        # 如果使用者沒有有自定番劇目錄或目錄不存在，則儲存在本地 bangumi 目錄
         settings['bangumi_dir'] = os.path.join(working_dir, 'bangumi')
 
-    # 如果用户自定了缓存目录且存在
+    # 如果使用者自定了快取目錄且存在
     if settings['temp_dir'] and os.path.exists(settings['temp_dir']):
-        # 缓存路径规范化
+        # 快取路徑規範化
         settings['temp_dir'] = os.path.abspath(settings['temp_dir'])
     else:
-        # 如果用户没有有自定缓存目录或目录不存在，则保存在本地 temp 目录
+        # 如果使用者沒有有自定快取目錄或目錄不存在，則儲存在本地 temp 目錄
         settings['temp_dir'] = os.path.join(working_dir, 'temp')
 
     settings['working_dir'] = working_dir
@@ -531,59 +531,59 @@ def read_settings(config=''):
     use_gost = False
     if not (re.match(r'^http://', settings['proxy'].lower())
             or re.match(r'^https://', settings['proxy'].lower())
-            or re.match(r'^socks5://', settings['proxy'].lower())  # v12开始原生支持 socks5 代理
-            or re.match(r'^socks5h://', settings['proxy'].lower())):  # socks5h 远程解析域名
-        #  如果出现非自身支持的协议
-        use_gost = True  # 则启用gost
+            or re.match(r'^socks5://', settings['proxy'].lower())  # v12 開始原生支援 socks5 代理
+            or re.match(r'^socks5h://', settings['proxy'].lower())):  # socks5h 遠端解析域名
+        #  如果出現非自身支援的協議
+        use_gost = True  # 則啟用 gost
     settings['use_gost'] = use_gost
     if not settings['proxy']:
         settings['use_proxy'] = False
 
     if settings['multi-thread'] > max_multi_thread:
-        # 如果线程数超限
+        # 如果執行緒數超限
         settings['multi-thread'] = max_multi_thread
 
     if settings['multi_downloading_segment'] > max_multi_downloading_segment:
-        # 如果并发分段数超限
+        # 如果併發分段數超限
         settings['multi_downloading_segment'] = max_multi_downloading_segment
 
     if settings['video_filename_extension'].lower() == 'flv':
-        # flv 格式会输出异常, 强制重置
+        # flv 格式會輸出異常，強制重置
         settings['video_filename_extension'] = 'mp4'
 
     if settings['video_filename_extension'].lower() != 'mp4':
-        # 如果封装格式不是 mp4 则强制关闭 metadata 前置
+        # 如果封裝格式不是 mp4 則強制關閉 metadata 前置
         settings['faststart_movflags'] = False
 
     if settings['save_logs']:
-        # 刪除过期日志
+        # 刪除過期日誌
         __remove_superfluous_logs(settings['quantity_of_logs'])
 
     if settings['use_dashboard']:
-        # 如果启用的控制台, 那么检查是否存在Dashboard目录
+        # 如果啟用的控制檯，那麼檢查是否存在 Dashboard 目錄
         if not os.path.exists(os.path.join(working_dir, 'Dashboard')):
             settings['use_dashboard'] = False
-            __color_print(0, 'Web控制面板', '未發現控制面板所必須的Dashboard資料夾, 强制禁用控制面板!', no_sn=True, status=1)
+            __color_print(0, 'Web控制面板', '未發現控制面板所必須的 Dashboard 資料夾，强制禁用控制面板！', no_sn=True, status=1)
             write_settings(settings)
 
     return settings
 
 
 def check_encoding(file_path):
-    # 识别文件编码, 将非 UTF-8 编码转为 UTF-8
+    # 識別檔案編碼，將非 UTF-8 編碼轉為 UTF-8
     with open(file_path, 'rb') as f:
         data = f.read()
-        file_encoding = chardet.detect(data)['encoding']  # 识别文件编码
+        file_encoding = chardet.detect(data)['encoding']  # 識別檔案編碼
         if file_encoding == 'utf-8' or file_encoding == 'ascii':
-            # 如果为 UTF-8 编码, 无需操作
+            # 如果為 UTF-8 編碼，無需操作
             return
         else:
-            # 如果为其他编码, 则转为 UTF-8 编码, 包含處理 BOM 頭
+            # 如果為其他編碼，則轉為 UTF-8 編碼，包含處理 BOM 頭
             with open(file_path, 'wb') as f2:
                 __color_print(0, '檔案讀取', file_path + ' 編碼為 ' + file_encoding + ' 將轉碼為 UTF-8', no_sn=True, status=1)
-                data = data.decode(file_encoding)  # 解码
-                data = data.encode('utf-8')  # 编码
-                f2.write(data)  # 写入文件
+                data = data.decode(file_encoding)  # 解碼
+                data = data.encode('utf-8')  # 編碼
+                f2.write(data)  # 寫入檔案
                 __color_print(0, '檔案讀取', file_path + ' 轉碼成功', no_sn=True, status=2)
 
 
@@ -599,7 +599,7 @@ def read_sn_list():
         return {}
 
     if not os.path.getsize(sn_list_path):
-        # 如果文件是空的, https://github.com/miyouzi/aniGamerPlus/issues/38
+        # 如果檔案是空的，https://github.com/miyouzi/aniGamerPlus/issues/38
         return {}
 
     # del_bom(sn_list_path)  # 去除 BOM
@@ -608,46 +608,46 @@ def read_sn_list():
         sn_dict = {}
         bangumi_tag = ''
         for i in f.readlines():
-            if re.match(r'^@.+', i):  # 读取番剧分类
+            if re.match(r'^@.+', i):  # 讀取番劇分類
                 bangumi_tag = i[1:-1]
                 continue
             elif re.match(r'^@ *', i):
                 bangumi_tag = ''
                 continue
-            i = re.sub(r'#.+\n', '', i).strip()  # 刪除注释
-            i = re.sub(r' +', ' ', i)  # 去除多余空格
-            a = i.split(" ")
-            if not a[0]:  # 跳过纯注释行
+            i = re.sub(r'#.+\n', '', i).strip()  # 刪除註釋
+            i = re.sub(r' +', ' ', i)  # 去除多餘空格
+            a = i.split(' ')
+            if not a[0]:  # 跳過純註釋行
                 continue
             if re.match(r'^\d+$', a[0]):
                 rename = ''
-                if len(a) > 1:  # 如果有特別指定下载模式
-                    if re.match(r'^(all|latest|largest-sn)$', a[1]):  # 仅认可合法的模式
+                if len(a) > 1:  # 如果有特別指定下載模式
+                    if re.match(r'^(all|latest|largest-sn)$', a[1]):  # 僅認可合法的模式
                         sn_dict[int(a[0])] = {'mode': a[1]}
                     else:
-                        sn_dict[int(a[0])] = {'mode': settings['default_download_mode']}  # 非法模式一律替换成默认模式
-                    # 是否有设定番剧重命名
+                        sn_dict[int(a[0])] = {'mode': settings['default_download_mode']}  # 非法模式一律替換成預設模式
+                    # 是否有設定番劇重新命名
                     if re.match(r'.*<.*>.*', i):
                         rename = re.findall(r'<.*>', i)[0][1:-1]
-                else:  # 没有指定下载模式则使用默认设定
+                else:  # 沒有指定下載模式則使用預設設定
                     sn_dict[int(a[0])] = {'mode': settings['default_download_mode']}
-                bangumi_tag = re.sub(r"( )+$", "", bangumi_tag)
+                bangumi_tag = re.sub(r'( )+$', '', bangumi_tag)
                 sn_dict[int(a[0])]['tag'] = bangumi_tag
                 sn_dict[int(a[0])]['rename'] = rename
         return sn_dict
 
 
 def test_cookie():
-    # 测试cookie.txt是否存在, 是否能正常读取, 并记录日志
+    # 測試 cookie.txt 是否存在，是否能正常讀取，並記錄日誌
     read_cookie(log=True)
 
 
 def read_cookie(log=False):
-    # 如果 cookie 已读入内存, 则直接返回
+    # 如果 cookie 已讀入記憶體，則直接返回
     global cookie
     if cookie is not None:
         return cookie
-    # 兼容旧版cookie命名
+    # 相容舊版 cookie 命名
     old_cookie_path = cookie_path.replace('cookie.txt', 'cookies.txt')
     if os.path.exists(old_cookie_path):
         os.rename(old_cookie_path, cookie_path)
@@ -655,35 +655,35 @@ def read_cookie(log=False):
     error_cookie_path = cookie_path.replace('cookie.txt', 'cookie.txt.txt')
     if os.path.exists(error_cookie_path):
         os.rename(error_cookie_path, cookie_path)
-    # 用户可以将cookie保存在程序所在目录下，保存为 cookies.txt ，UTF-8 编码
+    # 使用者可以將cookie儲存在程式所在目錄下，儲存為 cookies.txt ，UTF-8 編碼
     if os.path.exists(cookie_path):
         # del_bom(cookie_path)  # 移除 bom
         check_encoding(cookie_path)  # 移除 bom
         if log:
-            __color_print(0, '讀取cookie', detail='發現cookie檔案', no_sn=True, display=False)
+            __color_print(0, '讀取 cookie', detail='發現 cookie 檔案', no_sn=True, display=False)
         with open(cookie_path, 'r', encoding='utf-8') as f:
             for line in f.readlines():
-                if not line.isspace():  # 跳过空白行
-                    cookies = line.replace('\n', '')  # 刪除换行符
-                    cookies = dict([list(map(lambda x: quote(x, safe='') if re.match(r'[\u4e00-\u9fa5]', x) else x,  l.split("=", 1))) for l in cookies.split("; ")])
+                if not line.isspace():  # 跳過空白行
+                    cookies = line.replace('\n', '')  # 刪除換行符
+                    cookies = dict([list(map(lambda x: quote(x, safe='') if re.match(r'[\u4e00-\u9fa5]', x) else x,  l.split('=', 1))) for l in cookies.split('; ')])
                     cookies.pop('ckBH_lastBoard', 404)
                     cookie = cookies
                     if log:
-                        __color_print(0, '讀取cookie', detail='已讀取cookie', no_sn=True, display=False)
-                    return cookie  # cookie仅一行, 读到后马上return
+                        __color_print(0, '讀取 cookie', detail='已讀取 cookie', no_sn=True, display=False)
+                    return cookie  # cookie 僅一行，讀到後馬上 return
     else:
-        __color_print(0, '讀取cookie', detail='未發現cookie檔案', no_sn=True, display=False)
+        __color_print(0, '讀取 cookie', detail='未發現 cookie 檔案', no_sn=True, display=False)
         cookie = {}
         return cookie
     # 如果什么也没读到(空文件)
-    __color_print(0, '讀取cookie', detail='cookie檔案為空', no_sn=True, status=1)
+    __color_print(0, '讀取 cookie', detail='cookie 檔案為空', no_sn=True, status=1)
     invalid_cookie()
     cookie = {}
     return cookie
 
 
 def invalid_cookie():
-    # 当cookie失效时, 将cookie改名, 避免重复尝试失效的cookie
+    # 當 cookie 失效時，將 cookie 改名，避免重複嘗試失效的 cookie
     if os.path.exists(cookie_path):
         invalid_cookie_path = cookie_path.replace('cookie.txt', 'invalid_cookie.txt')
         try:
@@ -693,27 +693,27 @@ def invalid_cookie():
                 os.remove(invalid_cookie_path)
             os.rename(cookie_path, invalid_cookie_path)
         except BaseException as e:
-            __color_print(0, 'cookie狀態', '嘗試標記失效cookie時遇到未知錯誤: ' + str(e), no_sn=True, status=1)
+            __color_print(0, 'cookie 狀態', '嘗試標記失效 cookie 時遇到未知錯誤: ' + str(e), no_sn=True, status=1)
         else:
-            __color_print(0, 'cookie狀態', '已成功標記失效cookie', no_sn=True, display=False)
+            __color_print(0, 'cookie 狀態', '已成功標記失效 cookie', no_sn=True, display=False)
 
 
 def time_stamp_to_time(timestamp):
-    # 把时间戳转化为时间: 1479264792 to 2016-11-16 10:53:12
-    # 代码来自: https://www.cnblogs.com/shaosks/p/5614630.html
-    timeStruct = time.localtime(timestamp)
-    return time.strftime('%Y-%m-%d %H:%M:%S', timeStruct)
+    # 把時間戳轉化為時間: 1479264792 to 2016-11-16 10:53:12
+    # 程式碼來自: https://www.cnblogs.com/shaosks/p/5614630.html
+    time_struct = time.localtime(timestamp)
+    return time.strftime('%Y-%m-%d %H:%M:%S', time_struct)
 
 
 def get_cookie_time():
-    # 获取 cookie 修改时间
+    # 獲取 cookie 修改時間
     cookie_time = os.path.getmtime(cookie_path)
     return time_stamp_to_time(cookie_time)
 
 
 def renew_cookies(new_cookie, log=True):
     global cookie
-    cookie = None  # 重置cookie
+    cookie = None  # 重置 cookie
     new_cookie_str = ''
     for key, value in new_cookie.items():
         new_cookie_str = new_cookie_str + key + '=' + value + '; '
@@ -726,14 +726,14 @@ def renew_cookies(new_cookie, log=True):
                 f.write(new_cookie_str)
         except BaseException as e:
             if try_counter > 3:
-                __color_print(0, '新cookie保存失敗! 发生异常: ' + str(e), status=1, no_sn=True)
+                __color_print(0, '新 cookie 儲存失敗！發生異常：' + str(e), status=1, no_sn=True)
                 break
             random_wait_time = random.uniform(2, 5)
             time.sleep(random_wait_time)
             try_counter = try_counter + 1
         else:
             if log:
-                __color_print(0, '新cookie保存成功', no_sn=True, display=False)
+                __color_print(0, '新 cookie 儲存成功', no_sn=True, display=False)
             break
 
 
@@ -744,10 +744,10 @@ def read_latest_version_on_github():
     try:
         latest_releases_info = session.get(req, timeout=3).json()
         remote_version['tag_name'] = latest_releases_info['tag_name']
-        remote_version['body'] = latest_releases_info['body']  # 更新内容
+        remote_version['body'] = latest_releases_info['body']  # 更新內容
         __color_print(0, '檢查更新', '檢查更新成功', no_sn=True, display=False)
     except:
-        remote_version['tag_name'] = aniGamerPlus_version  # 拉取github版本号失败
+        remote_version['tag_name'] = aniGamerPlus_version  # 拉取 github 版本號失敗
         remote_version['body'] = ''
         __color_print(0, '檢查更新', '檢查更新失敗', no_sn=True, display=False)
     return remote_version
@@ -762,24 +762,24 @@ def __remove_superfluous_logs(max_num):
             for log in logs_need_remove:
                 log_path = os.path.join(logs_dir, log)
                 os.remove(log_path)
-                __color_print(0, '刪除過期日志: ' + log, no_sn=True, display=False)
+                __color_print(0, '刪除過期日誌：' + log, no_sn=True, display=False)
 
 
 def write_settings(web_config):
-    web_config = read_settings(web_config)  # 正规化配置
+    web_config = read_settings(web_config)  # 正規化設定
 
-    # 还原配置
-    a = os.path.join(working_dir, 'bangumi')  # 默认番剧目录
-    b = os.path.join(working_dir, 'temp')  # 默认缓存目录
+    # 還原設定
+    a = os.path.join(working_dir, 'bangumi')  # 預設番劇目錄
+    b = os.path.join(working_dir, 'temp')  # 預設快取目錄
     if os.path.normcase(web_config['bangumi_dir']) == os.path.normcase(a):
-        web_config["bangumi_dir"] = ''
+        web_config['bangumi_dir'] = ''
     if os.path.normcase(web_config['temp_dir']) == os.path.normcase(b):
         web_config['temp_dir'] = ''
     del web_config['working_dir']
     del web_config['aniGamerPlus_version']
     del web_config['use_gost']
 
-    # 配置写入磁盘
+    # 設定寫入磁碟
     with open(config_path, 'w', encoding='utf-8') as f:
         json.dump(web_config, f, ensure_ascii=False, indent=4)
 

--- a/Danmu.py
+++ b/Danmu.py
@@ -6,7 +6,7 @@ import os
 from ColorPrint import err_print
 
 
-class Danmu():
+class Danmu:
     def __init__(self, sn, full_filename):
         self._sn = sn
         self._full_filename = full_filename

--- a/Dashboard/Server.py
+++ b/Dashboard/Server.py
@@ -22,7 +22,7 @@ import logging, termcolor
 from ColorPrint import err_print
 from logging.handlers import TimedRotatingFileHandler
 import mimetypes
-# ws 支持
+# ws 支援
 import ssl
 from flask_sockets import Sockets
 from gevent.pywsgi import WSGIServer
@@ -37,29 +37,29 @@ app = Flask(__name__, template_folder=template_path, static_folder=static_path)
 app.debug = False
 sockets = Sockets(app)
 
-# 日志处理
+# 日誌處理
 # logger = logging.getLogger('werkzeug')
 logger = logging.getLogger('geventwebsocket')
-logging.basicConfig(level=logging.INFO)  # 记录访问
+logging.basicConfig(level=logging.INFO)  # 記錄訪問
 web_log_path = os.path.join(Config.get_working_dir(), 'logs', 'web.log')
 handler = TimedRotatingFileHandler(filename=web_log_path, when='midnight', backupCount=7, encoding='utf-8')
 handler.suffix = '%Y-%m-%d.log'
 handler.extMatch = re.compile(r'^\d{4}-\d{2}-\d{2}.log')
 logger.addHandler(handler)
-logger.propagate = False  # 不在控制台上输出
+logger.propagate = False  # 不在控制檯上輸出
 
-# websocket鉴权需要的 token, 随机一个 32 位初始 token
+# websocket 鑑權需要的 token，隨機一個 32 位初始 token
 websocket_token = ''.join(random.sample(string.ascii_letters + string.digits, 32))
 
 
-# 处理 Flask 写日志到文件带有颜色控制符的问题
+# 處理 Flask 寫日誌到檔案帶有顏色控制符的問題
 def colored(text, color=None, on_color=None, attrs=None):
-    who_invoked = traceback.extract_stack()[-2][2]  # 函数调用人
+    who_invoked = traceback.extract_stack()[-2][2]  # 函式呼叫人
     if who_invoked == 'log_request':
-        # 如果是来自 Flask/werkzeug 的调用
+        # 如果是來自 Flask/werkzeug 的呼叫
         return text
     else:
-        # 来自其他的调用正常高亮
+        # 來自其他的呼叫正常提示
         COLORS = termcolor.COLORS
         HIGHLIGHTS = termcolor.HIGHLIGHTS
         ATTRIBUTES = termcolor.ATTRIBUTES
@@ -81,7 +81,7 @@ termcolor.colored = colored
 app.logger.addHandler(handler)
 
 
-# 读取web需要的配置名称列表
+# 讀取 web 需要的設定名稱列表
 id_list_path = os.path.join(Config.get_working_dir(), 'Dashboard', 'static', 'js', 'settings_id_list.js')
 with open(id_list_path, 'r', encoding='utf-8') as f:
     id_list = re.sub(r'(var id_list\s*=\s*|\s*\n?)', '', f.read()).replace('\'', '"')
@@ -103,7 +103,7 @@ def config():
     settings = Config.read_settings()
     web_settings = {}
     for id in id_list:
-        web_settings[id] = settings[id]  # 仅返回 web 需要的配置
+        web_settings[id] = settings[id]  # 僅返回 web 需要的設定
 
     return jsonify(web_settings)
 
@@ -113,8 +113,8 @@ def recv_config():
     data = json.loads(request.get_data(as_text=True))
     new_settings = Config.read_settings()
     for id in id_list:
-        new_settings[id] = data[id]  # 更新配置
-    Config.write_settings(new_settings)  # 保存配置
+        new_settings[id] = data[id]  # 更新設定
+    Config.write_settings(new_settings)  # 儲存設定
     err_print(0, 'Dashboard', '通過 Web 控制臺更新了 config.json', no_sn=True, status=2)
     return '{"status":"200"}'
 
@@ -124,23 +124,23 @@ def manual_task():
     data = json.loads(request.get_data(as_text=True))
     settings = Config.read_settings()
 
-    # 下载清晰度
+    # 下载解析度
     if data['resolution'] not in ('360', '480', '540', '720', '1080'):
-        # 如果不是合法清晰度
+        # 如果不是合法解析度
         resolution = settings['download_resolution']
     else:
         resolution = data['resolution']
 
-    # 下载模式
+    # 下載模式
     if data['mode'] not in ('single', 'latest', 'all', 'largest-sn'):
         mode = 'single'
     else:
         mode = data['mode']
 
-    # 下载线程数
+    # 下載執行緒數
     thread = int(data['thread'])
     if thread > Config.get_max_multi_thread():
-        # 是否超过最大允许线程数
+        # 是否超過最大允許執行緒數
         thread_limit = Config.get_max_multi_thread()
     else:
         thread_limit = thread
@@ -150,7 +150,7 @@ def manual_task():
 
     server = threading.Thread(target=run_cui)
     err_print(0, 'Dashboard', '通過 Web 控制臺下達了手動任務', no_sn=True, status=2)
-    server.start()  # 启动手动任务线程
+    server.start()  # 啟動手動任務執行緒
     return '{"status":"200"}'
 
 
@@ -162,14 +162,14 @@ def show_sn_list():
 @app.route('/data/get_token', methods=['GET'])
 def get_token():
     global websocket_token
-    # 生成 32 位随机字符串作为token
+    # 生成 32 位隨機字串作為 token
     websocket_token = ''.join(random.sample(string.ascii_letters + string.digits, 32))
     return websocket_token, '200 ok'
 
 
 @sockets.route('/data/tasks_progress')
 def tasks_progress(ws):
-    # 鉴权
+    # 鑑權
     global websocket_token
     token = request.args.get('token')
     if token != websocket_token:
@@ -179,7 +179,7 @@ def tasks_progress(ws):
         # 一次性 token
         websocket_token = ''
 
-    # 推送任务进度数据
+    # 推送任務進度資料
     # https://blog.csdn.net/sinat_32651363/article/details/87912701
     while not ws.closed:
         msg = json.dumps(Config.tasks_progress_rate)
@@ -187,7 +187,7 @@ def tasks_progress(ws):
             ws.send(msg)
             time.sleep(1)
         except WebSocketError:
-            # 连接中断
+            # 連線中斷
             ws.close()
             break
 
@@ -201,20 +201,20 @@ def set_sn_list():
 
 
 def run():
-    settings = Config.read_settings()  # 读取配置
+    settings = Config.read_settings()  # 讀取設定
 
     if settings['dashboard']['BasicAuth']:
-        # BasicAuth 配置
+        # BasicAuth 設定
         app.config['BASIC_AUTH_USERNAME'] = settings['dashboard']['username']  # BasicAuth user
         app.config['BASIC_AUTH_PASSWORD'] = settings['dashboard']['password']  # BasicAuth password
-        app.config['BASIC_AUTH_FORCE'] = True  # 全站验证
+        app.config['BASIC_AUTH_FORCE'] = True  # 全站驗證
         basic_auth = BasicAuth(app)
 
     port = settings['dashboard']['port']
     host = settings['dashboard']['host']
 
     if settings['dashboard']['SSL']:
-        # SSL 配置
+        # SSL 設定
         ssl_path = os.path.join(Config.get_working_dir(), 'Dashboard', 'sslkey')
         ssl_crt = os.path.join(ssl_path, 'server.crt')
         ssl_key = os.path.join(ssl_path, 'server.key')
@@ -225,7 +225,7 @@ def run():
         wrap_socket = server.wrap_socket
         wrap_socket_and_handle = server.wrap_socket_and_handle
 
-        # 处理一些浏览器(比如Chrome)尝试 SSL v3 访问时报错
+        # 處理一些瀏覽器（例如Chrome）嘗試 SSL v3 存取時報錯
         def my_wrap_socket(sock, **_kwargs):
             try:
                 # print('my_wrap_socket')
@@ -234,7 +234,7 @@ def run():
                 # print('my_wrap_socket ssl.SSLError')
                 pass
 
-        # 此方法依赖上面的返回值, 因此当尝试访问 SSL v3 时, 这个也会出错
+        # 此方法依賴上面的返回值，Ｍ因此當嘗試訪問 SSL v3 時，這個也會出錯
         def my_wrap_socket_and_handle(client_socket, address):
             try:
                 # print('my_wrap_socket_and_handle')

--- a/Dashboard/static/js/aniGamerPlus.js
+++ b/Dashboard/static/js/aniGamerPlus.js
@@ -1,4 +1,4 @@
-var dataArrays; //用户配置json
+var dataArrays; // 使用者設定 json
 var proxy_protocol;
 var proxy_ip;
 var proxy_port;
@@ -52,19 +52,19 @@ function reloadSetting() {
 function readJson() {
 	$.getJSON("data/config.json", function(data) {
 		dataArrays = data;
-		parseProxy(data.proxy); // 解析代理配置
+		parseProxy(data.proxy); // 解析代理設定
 	});
 }
 
 function renderJson() {
 	for (var id of id_list) {
-		if (id == 'proxy') continue; //代理设置已被分解
+		if (id == 'proxy') continue; // 已解析代理設定
 		var idType = document.getElementById(id).type;
 		switch (idType) {
 			case 'text':
 			case 'number':
 			case 'password':
-				if (id  == 'multi-thread')  // 手动任务的默认线程数
+				if (id  == 'multi-thread')  // 手動任務的預設執行緒數
 					$('#manual_thread_limit').val(dataArrays[id]);
 				$("#" + id).val(dataArrays[id]);
 				break;
@@ -88,7 +88,7 @@ function renderJson() {
 
 function readSettings() {
 	for (var id of id_list) {
-		if (id == 'proxy') continue; //代理设置已被分解
+		if (id == 'proxy') continue; // 手動任務的預設執行緒數
 
 		var idType = document.getElementById(id).type;
 		switch (idType) {
@@ -113,16 +113,16 @@ function readSettings() {
 				break;
 		}
 
-		// 合并代理配置
+		// 合併代理設定
 		var a = ['proxy_protocol', 'proxy_ip', 'proxy_port', 'proxy_user', 'proxy_passwd'];
 		for (var i in a) {
 			var ip_port = dataArrays["proxy_ip"] + ':' + dataArrays["proxy_port"];
 			var protocol = dataArrays["proxy_protocol"] + '://';
 			if (dataArrays["proxy_user"]?.length * dataArrays["proxy_passwd"]?.length == 0) {
-				// 如果没有用户密码
+				// 如果沒有使用者密碼
 				dataArrays["proxy"] = protocol + ip_port;
 			} else {
-				// 如果有用户密码
+				// 如果有使用者密碼
 				var user_pw = dataArrays["proxy_user"] + ':' + dataArrays["proxy_passwd"] + '@';
 				dataArrays["proxy"] = protocol + user_pw + ip_port;
 			}
@@ -140,14 +140,14 @@ function readSettings() {
 		contentType: 'application/json; charset=utf-8',
 		data: JSON.stringify(dataArrays),
 		success: function(data) {
-			// 向用户提示提交成功
+			// 向使用者提示送出成功
 			$('#uploadOk').show();
 			$('#uploadFailed').hide();
 			$('#uploadStatus').modal();
 			reloadSetting();
 		},
 		error:function(status){
-			// 向用户提示提交失败
+			// 向使用者提示送出失敗
 			$('#uploadOk').hide();
 			$('#uploadFailed').show();
 			$('#uploadStatus').modal();
@@ -157,14 +157,14 @@ function readSettings() {
 
 function getUA(){
 	$('#ua').val(navigator.userAgent);
-	alert("已取得當前瀏覽器UA");
+	alert("已取得當前瀏覽器 UA");
 }
 
 function readManualConfig(){
 	var manualData = {};
 	var link = $('#manual_link').val();
 	if (link.length == 0) {
-		alert('請輸入影片鏈接！')
+		alert('請輸入影片連結！')
 	} else {
 		var sn = link.replace(/(https:\/\/)?ani\.gamer\.com\.tw\/animeVideo\.php\?sn=/i, '');
 		manualData['sn'] = sn;
@@ -194,14 +194,14 @@ function readManualConfig(){
 			contentType: 'application/json; charset=utf-8',
 			data: JSON.stringify(manualData),
 			success: function(data) {
-				// 向用户提示提交成功
+				// 向使用者提示送出成功
 				$('#uploadOk').show();
 				$('#uploadFailed').hide();
 				$('#uploadStatus').modal();
 				reloadSetting();
 			},
 			error:function(status){
-				// 向用户提示提交失败
+				// 向使用者提示送出失敗
 				$('#uploadOk').hide();
 				$('#uploadFailed').show();
 				$('#uploadStatus').modal();
@@ -224,14 +224,14 @@ function postSnList(){
 		contentType: 'text/plain; charset=utf-8',
 		data: sn_list,
 		success: function(data) {
-			// 向用户提示提交成功
+			// 向使用者提示送出成功
 			$('#uploadOk').show();
 			$('#uploadFailed').hide();
 			$('#uploadStatus').modal();
 			showSnList();
 		},
 		error:function(status){
-			// 向用户提示提交失败
+			// 向使用者提示送出失敗
 			$('#uploadOk').hide();
 			$('#uploadFailed').show();
 			$('#uploadStatus').modal();

--- a/Dashboard/static/js/monitor.js
+++ b/Dashboard/static/js/monitor.js
@@ -5,7 +5,7 @@ layui.use('element', function(){
 	let ws = protocol.replace('http', 'ws');
 	let tasks_progress_url = ws+'//'+window.location.host+'/data/tasks_progress'+'?token=';
 	
-	// 获取token
+	// 獲取 token
 	$.get('data/get_token', function(token){
 		tasks_progress_url += token;
 		
@@ -19,12 +19,12 @@ layui.use('element', function(){
 				for (let sn in data){
 					
 					if ($('#'+sn).length > 0) {
-						// 如果该任务卡片已存在
+						// 如果該任務卡片已存在
 						$("#status"+sn).html(data[sn]["status"]);
 						$("#header"+sn).html(data[sn]["filename"]);						
 						element.progress(sn, Math.round(data[sn]["rate"])+'%');
 					} else {
-						// 如果该任务卡片不存在
+						// 如果該任務卡片不存在
 						let task_item_templates = `
 							<div class="layui-col-xs12 layui-card" id=${sn}>
 								<div class="layui-card-header" style="height:auto !important;" id=${"header"+sn}>${data[sn]["filename"]}</div>

--- a/Dashboard/templates/index.html
+++ b/Dashboard/templates/index.html
@@ -16,11 +16,11 @@
 		<script src="../static/js/aniGamerPlus.js"></script>
 		<meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0" />
 		<link rel="shortcut icon" href="../static/img/aniGamerPlus.ico" type="image/x-icon" />
-		<title>aniGamerPlus控制臺</title>
+		<title>aniGamerPlus 控制臺</title>
 	</head>
 	<body>
 		<nav class="navbar navbar-expand-md bg-dark navbar-dark fixed-top">
-			<a class="navbar-brand" href="#">aniGamerPlus控制臺</a>
+			<a class="navbar-brand" href="#">aniGamerPlus 控制臺</a>
 
 			<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapsibleNavbar">
 				<span class="navbar-toggler-icon"></span>
@@ -37,28 +37,28 @@
 						<a class="nav-link" href="#" data-toggle="modal" data-target="#snList">sn_list</a>
 					</li>
 					<li class="nav-item my-navbar">
-						<button class="btn btn-success" type="button" data-toggle="modal" data-target="#manualTasks">添加手動任務</button>
+						<button class="btn btn-success" type="button" data-toggle="modal" data-target="#manualTasks">手動新增任務</button>
 					</li>
 				</ul>
 			</div>
 		</nav>
 
-		<!-- 手动模式模态框 -->
+		<!-- 手動模式動態框 -->
 		<div class="modal fade" id="manualTasks">
 			<div class="modal-dialog modal-lg">
 				<div class="modal-content">
-					<!-- 模态框头部 -->
+					<!-- 模組頂部 -->
 					<div class="modal-header">
-						<h4 class="modal-title">手動添加任務</h4>
+						<h4 class="modal-title">手動新增任務</h4>
 						<button type="button" class="close" data-dismiss="modal">&times;</button>
 					</div>
-					<!-- 模态框主体 -->
+					<!-- 模組框主體 -->
 					<div class="modal-body setting-wrapper">
 						<form>
 							<div class="row setting-content setting-content">
 								<div class="input-group">
 									<div class="input-group-prepend">
-										<span class="input-group-text">影片鏈接</span>
+										<span class="input-group-text">影片連結</span>
 									</div>
 									<input id="manual_link" type="text" class="form-control input-group-prepend-form-control" />
 								</div>
@@ -108,7 +108,7 @@
 
 							<div class="row input-group setting-content" style="max-width: 15rem;">
 								<div class="input-group-prepend">
-									<span class="input-group-text">最大并發下載數</span>
+									<span class="input-group-text">最大併發下載數</span>
 								</div>
 								<input id="manual_thread_limit" type="number" min="1" step="1" class="form-control input-group-prepend-form-control"
 								 placeholder="正整數" />
@@ -118,40 +118,40 @@
 
 						</form>
 					</div>
-					<!-- 模态框底部 -->
+					<!-- 模組框底部 -->
 					<div class="modal-footer">
-						<button type="button" class="btn btn-success" onclick="readManualConfig()">提交</button>
-						<button type="button" class="btn btn-secondary" data-dismiss="modal">关闭</button>
+						<button type="button" class="btn btn-success" onclick="readManualConfig()">送出</button>
+						<button type="button" class="btn btn-secondary" data-dismiss="modal">關閉</button>
 					</div>
 				</div>
 			</div>
 		</div>
 
-		<!-- sn_list 模态框 -->
+		<!-- sn_list 模組框 -->
 		<div class="modal fade" id="snList">
 			<div class="modal-dialog modal-lg">
 				<div class="modal-content">
 
-					<!-- 模态框头部 -->
+					<!-- 模組框頂部 -->
 					<div class="modal-header">
 						<h4 class="modal-title">sn_list</h4>
 						<button type="button" class="close" data-dismiss="modal">&times;</button>
 					</div>
 
-					<!-- 模态框主体 -->
+					<!-- 模組框主體 -->
 					<div class="modal-body setting-wrapper">
 						<dl>
 							<dt>格式：</dt>
 							<dd><code>
 									@分類(可空)<br>
-									sn碼 下載模式(可空) 	&lt;重命名&gt;(可空) #注釋(可空)
+									sn碼 下載模式(可空) 	&lt;重命名&gt;(可空) #註解(可空)
 								</code></dd>
 
 							<dt>説明</dt>
-							<dd>注釋 <kbd>#</kbd> 後面的所有字符程序均不會讀取, 可以用於標記番劇名</dd>
-							<dd>在一排番劇列表的上方 <kbd>@</kbd> 開頭後面的字符將會作爲番劇的分類名, 番劇會歸類在此分類名的資料夾下</dd>
+							<dd>註解 <kbd>#</kbd> 後面的所有字符程式均不會讀取，可以用於標記番劇名</dd>
+							<dd>在一排番劇列表的上方 <kbd>@</kbd> 開頭後面的字符將會作爲番劇的分類名，番劇會歸類在此分類名的資料夾下</dd>
 							<dd>若單獨 <kbd>@</kbd> 表示不分類</dd>
-							<dd>用 <kbd>&lt;</kbd> 與 <kbd>&gt;</kbd> 將自定義的番劇名框起來, 下載時將會使用這個名字作爲番劇目錄名</dd>
+							<dd>用 <kbd>&lt;</kbd> 與 <kbd>&gt;</kbd> 將自定義的番劇名框起來，下載時將會使用這個名字作爲番劇目錄名</dd>
 						</dl>
 
 						<form>
@@ -162,10 +162,10 @@
 						
 					</div>
 
-					<!-- 模态框底部 -->
+					<!-- 模組框底部 -->
 					<div class="modal-footer">
-						<button type="button" class="btn btn-success" onclick="postSnList()">提交</button>
-						<button type="button" class="btn btn-secondary" data-dismiss="modal">关闭</button>
+						<button type="button" class="btn btn-success" onclick="postSnList()">送出</button>
+						<button type="button" class="btn btn-secondary" data-dismiss="modal">關閉</button>
 					</div>
 
 				</div>
@@ -173,28 +173,28 @@
 		</div>
 
 
-		<!-- 提交请求模态框 -->
+		<!-- 送出請求模組框 -->
 		<div class="modal fade" id="uploadStatus">
 			<div class="modal-dialog modal-sm" role="document">
 				<div class="modal-content">
 
-					<!-- 模态框头部 -->
+					<!-- 模組框頂部 -->
 					<div class="modal-header">
-						<h4 class="modal-title">提交結果</h4>
+						<h4 class="modal-title">送出結果</h4>
 						<button type="button" class="close" data-dismiss="modal">&times;</button>
 					</div>
 
-					<!-- 模态框主体 -->
+					<!-- 模組框主體 -->
 					<div class="modal-body setting-wrapper">
 						<center>
 							<div id="uploadOk" style="display: none;">
 								<i class="far fa-check-circle fa-4x" style="color: #28A745;"></i>
-								<p class="upload-status">配置已成功提交</p>
+								<p class="upload-status">設定已成功送出</p>
 							</div>
 
 							<div id="uploadFailed" style="display: block;">
 								<i class="fas fa-exclamation-circle fa-4x" style="color: #DC3545;"></i>
-								<p class="upload-status">配置提交失敗</p>
+								<p class="upload-status">設定送出失敗</p>
 							</div>
 
 
@@ -202,16 +202,16 @@
 
 					</div>
 
-					<!-- 模态框底部 -->
+					<!-- 模組框底部 -->
 					<div class="modal-footer">
-						<button type="button" class="btn btn-secondary" data-dismiss="modal">关闭</button>
+						<button type="button" class="btn btn-secondary" data-dismiss="modal">關閉</button>
 					</div>
 
 				</div>
 			</div>
 		</div>
 
-		<!-- 自动模式配置界面主体 -->
+		<!-- 自動模式設定界面主體 -->
 		<div class="setting-wrapper mx-auto" style="padding-top: 70px;">
 			<form>
 				<div class="row">
@@ -230,7 +230,7 @@
 						<div class="input-group-prepend">
 							<span class="input-group-text">暫存目錄</span>
 						</div>
-						<input id="temp_dir" type="text" class="form-control input-group-prepend-form-control" placeholder="放空則存放於程式所在資料夾" />
+						<input id="temp_dir" type="text" class="form-control input-group-prepend-form-control" placeholder="留空則存放於程式所在資料夾" />
 					</div>
 				</div>
 
@@ -258,14 +258,14 @@
 					</div>
 					<div class="input-group col-md-4 my-button">
 						<div class="input-group-prepend">
-							<span class="input-group-text">檔名添加番劇名</span>
+							<span class="input-group-text">檔名新增番劇名</span>
 							<input id="add_bangumi_name_to_video_filename" type="checkbox" data-toggle="switch" data-on-color="success"
 							 　data-size="normal" />
 						</div>
 					</div>
 					<div class="input-group col-md-4 my-button">
 						<div class="input-group-prepend">
-							<span class="input-group-text">檔名添加解析度</span>
+							<span class="input-group-text">檔名新增解析度</span>
 							<input id="add_resolution_to_video_filename" type="checkbox" data-toggle="switch" data-on-color="success"
 							 　data-size="normal" />
 						</div>
@@ -313,14 +313,14 @@
 					</div>
 					<div class="input-group col-md-4 my-button">
 						<div class="input-group-prepend">
-							<span class="input-group-text">最大并發下載數</span>
+							<span class="input-group-text">最大併發下載數</span>
 						</div>
 						<input id="multi-thread" type="number" min="1" step="1" class="form-control input-group-prepend-form-control"
 						 placeholder="正整數" />
 					</div>
 					<div class="input-group col-md-4 my-button">
 						<div class="input-group-prepend">
-							<span class="input-group-text">最大并發分段數</span>
+							<span class="input-group-text">最大併發分段數</span>
 						</div>
 						<input id="multi_downloading_segment" type="number" min="1" step="1" class="form-control input-group-prepend-form-control"
 						 placeholder="正整數" />
@@ -339,10 +339,10 @@
 					</div>
 					<div class="input-group col-md-12 my-button">
 						<div class="input-group-prepend">
-							<span class="input-group-text">請求UA　　　　</span>
+							<span class="input-group-text">請求 UA　　　　</span>
 						</div>
 						<input id="ua" type="text" class="form-control input-group-prepend-form-control" placeholder="若有使用cookie請與取得cookie的瀏覽器保持一致" />
-						<button type="button" class="btn btn-dark" onclick="getUA()">取得當前UA</button>
+						<button type="button" class="btn btn-dark" onclick="getUA()">取得當前 UA</button>
 					</div>
 				</div>
 
@@ -369,7 +369,7 @@
 					</div>
 					<div class="input-group col-md-4 my-button">
 						<div class="input-group-prepend">
-							<span class="input-group-text">伺服器IP</span>
+							<span class="input-group-text">伺服器 IP</span>
 						</div>
 						<input id="proxy_ip" type="text" class="form-control input-group-prepend-form-control" placeholder="127.0.0.1" />
 					</div>
@@ -381,7 +381,7 @@
 					</div>
 					<div class="input-group col-md-6 my-button">
 						<div class="input-group-prepend">
-							<span class="input-group-text">用戶名</span>
+							<span class="input-group-text">使用者名稱</span>
 						</div>
 						<input id="proxy_user" type="text" class="form-control input-group-prepend-form-control" placeholder="沒有放空即可" />
 					</div>
@@ -400,42 +400,42 @@
 				<div class="row setting-content">
 					<div class="input-group col-md-4 my-button">
 						<div class="input-group-prepend">
-							<span class="input-group-text">啓動時檢查更新</span>
+							<span class="input-group-text">啟動時檢查更新</span>
 							<input id="check_latest_version" type="checkbox" data-toggle="switch" data-on-color="success" 　data-size="normal" />
 						</div>
 					</div>
 					<div class="input-group col-md-4 my-button">
 						<div class="input-group-prepend">
-							<span class="input-group-text">每次檢查讀取sn_list</span>
+							<span class="input-group-text">每次檢查讀取 sn_list</span>
 							<input id="read_sn_list_when_checking_update" type="checkbox" data-toggle="switch" data-on-color="success"
 							 　data-size="normal" />
 						</div>
 					</div>
 					<div class="input-group col-md-4 my-button">
 						<div class="input-group-prepend">
-							<span class="input-group-text">每次檢查讀取配置</span>
+							<span class="input-group-text">每次檢查讀取設定</span>
 							<input id="read_config_when_checking_update" type="checkbox" data-toggle="switch" data-on-color="success"
 							 　data-size="normal" />
 						</div>
 					</div>
 					<div class="input-group col-md-4 my-button">
 						<div class="input-group-prepend">
-							<span class="input-group-text">記錄日志</span>
+							<span class="input-group-text">記錄日誌</span>
 							<input id="save_logs" type="checkbox" data-toggle="switch" data-on-color="success" 　data-size="normal" />
 						</div>
 					</div>
 					<div class="input-group col-md-4 my-button">
 						<div class="input-group-prepend">
-							<span class="input-group-text">日志數量</span>
+							<span class="input-group-text">日誌數量</span>
 						</div>
 						<input id="quantity_of_logs" type="number" min="1" step="1" class="form-control input-group-prepend-form-control"
-						 placeholder="正整數, 每天一個日志" />
+						 placeholder="正整數，每天一個日志" />
 					</div>
 				</div>
 				<br /><br />
 				<center>
-					<button type="button" class="btn btn-success" onclick="readSettings()">保存</button>
-					<button type="button" class="btn btn-danger" onclick="reloadSetting()">重載配置</button>
+					<button type="button" class="btn btn-success" onclick="readSettings()">儲存</button>
+					<button type="button" class="btn btn-danger" onclick="reloadSetting()">重載設定</button>
 				</center>
 
 			</form>

--- a/Dashboard/templates/login.html
+++ b/Dashboard/templates/login.html
@@ -20,7 +20,7 @@
 			</form>
 			<div class="error-pw alert alert-danger alert-dismissible fade show">
 				<button type="button" class="close" data-dismiss="alert">&times;</button>
-				<strong>ERROR</strong> 錯誤的密碼
+				<strong>ERROR</strong> 密碼錯誤
 			</div>
 		</div>
 		

--- a/Dashboard/templates/monitor.html
+++ b/Dashboard/templates/monitor.html
@@ -11,11 +11,11 @@
 		<link rel="stylesheet" href="../static/layui/css/layui.css">
 		<link rel="stylesheet" href="../static/css/aniGamerPlus.css" />
 		<link rel="shortcut icon" href="../static/img/aniGamerPlus.ico" type="image/x-icon" />
-		<title>aniGamerPlus任務監控中心</title>
+		<title>aniGamerPlus 任務監控中心</title>
 	</head>
 	<body>
 		<nav class="navbar navbar-expand-md bg-dark navbar-dark fixed-top">
-			<a class="navbar-brand" href="#">aniGamerPlus控制臺</a>
+			<a class="navbar-brand" href="#">aniGamerPlus 控制臺</a>
 		
 			<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapsibleNavbar">
 				<span class="navbar-toggler-icon"></span>

--- a/Dashboard/templates/register.html
+++ b/Dashboard/templates/register.html
@@ -9,15 +9,15 @@
 		<link rel="stylesheet" href="../static/css/aniGamerPlus.css"/>
 		<meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0" />
 		<link rel="shortcut icon" href="../static/img/aniGamerPlus.ico" type="image/x-icon" />
-		<title>注冊 - aniGamerPlus控制臺</title>
+		<title>註冊 - aniGamerPlus控制臺</title>
 	</head>
 	<body>
 		<div class="login-wrapper">
 			<form class="login-content">
-				<h1>注冊密碼</h1>
+				<h1>註冊密碼</h1>
 				<input type="password" class="form-control" id="pw1" placeholder="輸入密碼" />
 				<input type="password" class="form-control" id="pw2" placeholder="再次輸入密碼" />
-				<button type="button" class="btn btn-success">注冊</button>
+				<button type="button" class="btn btn-success">註冊</button>
 			</form>
 		</div>
 		

--- a/README.md
+++ b/README.md
@@ -152,37 +152,37 @@ docker run -td --name anigamerplus \
     "check_frequency": 5,  # 檢查更新頻率，單位為分鐘
     "download_resolution": "1080",  # 下載選取解析度，若該解析度不存在將會選取最近可用解析度，可選 360 480 540 576 720 1080
     "lock_resolution": false,  # 鎖定解析度，如果指定解析度不存在，則放棄下載
-    "only_use_vip": false,  # 锁定 VIP 账号下载
+    "only_use_vip": false,  # 锁定 VIP 帳號下載
     "default_download_mode": "latest",  # 默認下載模式，另一可選參數為 all 和 largest-sn. latest 為僅下載最後一集，all 下載番劇全部劇集，largest-sn 下載最近上傳的一集
     "use_copyfile_method": false,  # 轉移影片至番劇資料夾時使用複製方法, 適用於儲存到 rclone 掛載盤的情況
-    "multi-thread": 1,  # 最大併發下載數, 最高為 5, 超過將重置為 5
+    "multi-thread": 1,  # 最大併發下載數，最高為 5，超過將重置為 5
     "multi_upload": 3,  # 最大併發上傳數
-    "segment_download_mode": true,  # 分段下載模式, 速度更快, 容錯率更高
-    "segment_max_retry": 8,  # 在分段下載模式時有效, 每個分段最大重試次數, -1 為無限重試
-    "multi_downloading_segment": 3,  # 每個影片最大併發下載分段數, 僅在 "segment_download_mode" 為 true 時有效, 最高為 5, 超過將重置為 5
-    "add_bangumi_name_to_video_filename": true,  # 如果為 false, 則只有劇集名, 若劇集名為個位數字, 則補零
-    "add_resolution_to_video_filename": true,  # 是否在影片檔名中添加解析度, 格式舉例: [1080P]
+    "segment_download_mode": true,  # 分段下載模式，速度更快，容錯率更高
+    "segment_max_retry": 8,  # 在分段下載模式時有效，每個分段最大重試次數，-1 為無限重試
+    "multi_downloading_segment": 3,  # 每個影片最大併發下載分段數，僅在 "segment_download_mode" 為 true 時有效，最高為 5，超過將重置為 5
+    "add_bangumi_name_to_video_filename": true,  # 如果為 false，則只有劇集名，若劇集名為個位數字，則補零
+    "add_resolution_to_video_filename": true,  # 是否在影片檔名中添加解析度, 格式舉例：[1080P]
     "customized_video_filename_prefix": "【動畫瘋】",  # 影片檔名前綴
-    "customized_bangumi_name_suffix": "",  # 影片檔名中番劇名的後缀, 在劇集名之前
+    "customized_bangumi_name_suffix": "",  # 影片檔名中番劇名的後缀，在劇集名之前
     "customized_video_filename_suffix": "",  # 影片檔名後綴
-    "video_filename_extension": "mp4",  # 影片檔副檔名, ts, mov, mkv 經過測試可以使用, 但 flv 不支援, 非 mp4 副檔名 faststart_movflags 將强制為 false
-    "zerofill": 1,  # 劇集名補零, 填寫補足位數, 例: 填寫 2 劇集名為 01, 填寫 3 劇集名為 001
-    "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Safari/537.36",  #  請求UA, 需要和獲取cookie的瀏覽器相同
+    "video_filename_extension": "mp4",  # 影片檔副檔名，ts、mov、mkv 經過測試可以使用，但 flv 不支援，非 mp4 副檔名 faststart_movflags 將强制為 false
+    "zerofill": 1,  # 劇集名補零, 填寫補足位數, 例: 填寫 2 劇集名為 01，填寫 3 劇集名為 001
+    "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Safari/537.36",  #  請求 UA，需要和獲取 cookie 的瀏覽器相同
     "use_proxy": false,  # 代理開關
     "proxy": {"http://user:passwd@example.com:1000"},  # 代理設定
     "upload_to_server": false,  # 上傳功能開關
     "ftp": {  # FTP設定
         "server": "",  # FTP Server IP
-        "port": "",  # 端口
+        "port": "",  # 埠號
         "user": "",  # 使用者名
         "pwd": "",  # 密碼
         "tls": true,  # 是否是 FTP over TLS
         "cwd": "",  # 登入後首先進入的目錄
         "show_error_detail": false,  # 是否顯示細節錯誤訊息
-        "max_retry_num": 15  # 最大重傳數, 支援續傳
+        "max_retry_num": 15  # 最大重傳數，支援續傳
     },
-    "user_command": "shutdown -s -t 60"  # 命令列模式使用 -u 參數有效, 在命令列模式下完成所有任務後執行的命令
-    "coolq_notify": false,  # 是否向酷Q推送下載完成訊息
+    "user_command": "shutdown -s -t 60"  # 命令列模式使用 -u 參數有效，在命令列模式下完成所有任務後執行的命令
+    "coolq_notify": false,  # 是否向 酷Q 推送下載完成訊息
     "coolq_settings": {
         "msg_argument_name": "message",
         "message_suffix": "追加的資訊",
@@ -191,11 +191,15 @@ docker run -td --name anigamerplus \
             "http://127.0.0.1:5700/send_group_msg?access_token=abc&group_id=87654321"
         ]
     },
-    "faststart_movflags": false,  # 是否將影片 metadata 前置, 啟用此功能時在線觀看會更快播放, 僅在 video_filename_extension 為 mp4 時有效
+    "telebot_notify": false,  # 是否開啟 telegram 通知
+    "telebot_token": "",  # telegram 機器人 token
+    "discord_notify": true,  # 是否開啟 discord 通知
+    "discord_token": "https://",  # discord webhook api 網址
+    "faststart_movflags": false,  # 是否將影片 metadata 前置，啟用此功能時在線觀看會更快播放，僅在 video_filename_extension 為 mp4 時有效
     "audio_language": false,  # 是否添加音軌標簽
-    "use_mobile_api": false,  # 使用移動端API進行影片解析
+    "use_mobile_api": false,  # 使用移動端 API 進行影片解析
     "check_latest_version": true,  # 是否檢查更新
-    "read_sn_list_when_checking_update": true,  # 是否在檢查更新時讀取sn_list.txt, 開啟後對sn_list.txt的更改將會在下次檢查更新時生效而不用重啟程式
+    "read_sn_list_when_checking_update": true,  # 是否在檢查更新時讀取sn_list.txt, 開啟後對 sn_list.txt 的更改將會在下次檢查更新時生效而不用重啟程式
     "read_config_when_checking_update": true,  # 是否在檢查更新時讀取設定文件, 開啟後對設定文件的更改將會在下次檢查時更新生效而不用重啟程式
     "ads_time": 25,  # 非VIP廣告等待時間, 如果等待時間不足, 程式會自行追加時間 (最大20秒)
     "mobile_ads_time":3  # 使用移動端API解析的廣告等待時間
@@ -203,7 +207,7 @@ docker run -td --name anigamerplus \
     "dashboard": {  # Web控制面板設定
         "host": "127.0.0.1",  # 監聽地址, 如果需要允許外部訪問, 請填寫 "0.0.0.0"
         "port": 5000,  # 監聽端口
-        "SSL": false,  # 是否開啟SSL, 證書儲存在 Dashboard\sslkey, 如果有需要可以自行替換證書
+        "SSL": false,  # 是否開啟SSL, 證書儲存在 Dashboard/sslkey, 如果有需要可以自行替換證書
         "BasicAuth": false,  # 是否使用 BasicAuth 進行認證, 注意, 用戶密碼是明文傳輸的, 如有需要建議同時啟用 SSL
         "username": "admin",  # BasicAuth 用戶名
         "password": "admin"  # BasicAuth 密碼

--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@
  <img alt="GitHub Releases" src="https://img.shields.io/github/downloads/miyouzi/aniGamerPlus/latest/total.svg?style=flat-square">
 </p>
 
-巴哈姆特動畫瘋自動下載工具, 可隨著番劇更新自動下載, 適合部署在全天開機的伺服器或NAS上.
+巴哈姆特動畫瘋自動下載工具，可隨著番劇更新自動下載，適合部署在全天開機的伺服器或NAS上。
 
-同時支援命令行, 也適用於需要大批量下載的使用者, 如: 下載整部番劇. 命令行模式支援顯示下載進度, 但要求 **最大并發下載數** 設置為 **1** .
+同時支援命令列，也適用於需要大批量下載的使用者，如：下載整部番劇。命令列模式支援顯示下載進度，但要求 **最大併發下載數** 設定為 **1** 。
 
 ## **注意**:warning:
 
-**本專案依賴ffmpeg, 請事先將ffmpeg放入系統PATH或者本程序目錄下!**
+**本專案依賴 ffmpeg，請事先將 ffmpeg 放入系統 PATH 或者本程式目錄下！**
 
-ffmpeg 需要另外下載, [**點擊這裡前往下載頁**](https://ffmpeg.org/download.html). 若不知道如何將 ffmpeg 放入 PATH 則直接將 **ffmpeg.exe** 放在和本程式同一個資料夾下即可.
+ffmpeg 需要另外下載，[**點擊這裡前往下載頁**](https://ffmpeg.org/download.html) 。若不知道如何將 ffmpeg 放入 PATH 則直接將 **ffmpeg.exe** 放在和本程式同一個資料夾下即可。
 
-## EXE 檔案運行(對於不熟悉Python的使用者)
+## EXE 檔案運行（對於不熟悉 Python 的使用者）
 
 windows 使用者可以[**點擊這裡**](https://github.com/miyouzi/aniGamerPlus/releases/latest)下載exe文件使用.
 
@@ -25,7 +25,7 @@ windows 使用者可以[**點擊這裡**](https://github.com/miyouzi/aniGamerPlu
 
 Python 版本 3 以上
 
-**使用前确认已安装好依赖**
+**使用前確認已安裝好依賴**
 ```
 pip3 install requests beautifulsoup4 lxml termcolor chardet pysocks
 pip3 install Flask Flask_BasicAuth Flask_Sockets gevent gevent_websocket
@@ -48,7 +48,7 @@ python3 aniGamerPlus.py
 
 ## Docker 運行
 
-### (可選) 建構自己的 Image
+### 建構自己的 Image（可選）
 
 下載原始碼
 
@@ -66,13 +66,13 @@ docker build -t anigamerplus .
 
 目前官方 Image 放在 `tonypepe/anigamerplus`
 
-使用前需在本地先創建好 config.json，並綁定 config.json 和下載目錄至 Container 內。
+使用前需在本地先建立好 config.json，並映射 config.json 和下載目錄至 Container 內。
 
 注意：
 
-1. confg.json 中的 Dashboard Host 請設定成 `0.0.0.0`，切勿設定 `127.0.0.1`.
+1. confg.json 中的 Dashboard Host 請設定成 `0.0.0.0`，切勿設定 `127.0.0.1`。
 2. config.json 勿設定下載目錄 `bangumi_dir: ""`，請保持為空，以免目錄綁定失敗。
-3. 可綁定 cookie.txt 至 `/app/cookie.txt`
+3. 可映射 cookie.txt 至 `/app/cookie.txt`
 
 使用：
 
@@ -89,99 +89,99 @@ docker run -td --name anigamerplus \
 
 ## 鳴謝
 
-本專案m3u8获取模塊參考自 [BahamutAnimeDownloader](https://github.com/c0re100/BahamutAnimeDownloader)
+本專案 m3u8 獲取模組參考自 [BahamutAnimeDownloader](https://github.com/c0re100/BahamutAnimeDownloader)
 
 ## 第三方拓展工具
  - [aniGamerPlus-swapHistorySnList](https://github.com/chumicat/aniGamerPlus-swapHistorySnList)
-    - 將資料庫中的番劇導出到sn_list, 可方便的與原來的sn_list相互切換, 適用於你想檢查過往番劇是否有更新時.
+    - 將資料庫中的番劇導出到sn_list，可方便的與原來的sn_list相互切換，適用於你想檢查過往番劇是否有更新時。
 
 ## 目錄
 
 * [特性](#特性)
 * [注意](#注意warning)
 * [任務列表](#任務列表)
-* [配置説明](#配置説明)
-    * [主配置 config.json](#configjson)
+* [設定説明](#設定説明)
+    * [主設定 config.json](#configjson)
     * [使用代理](#使用代理)
     * [下載模式説明](#下載模式説明)
     * [使用 cookie](#cookietxt)
-    * [自動下載配置 sn_list.txt](#sn_listtxt)
+    * [自動下載設定 sn_list.txt](#sn_listtxt)
     * [任務狀態資料庫 aniGamer.db](#anigamerdb)
-* [命令行使用](#命令行使用)
+* [命令列使用](#命令列使用)
 * [Web控制臺使用](#Dashboard)
 
 ## 特性
 
- - 支援多綫程下載
- - 支援cookie，支援下載 1080P
- - 下載模式有僅下載最新一集, 下載最新上傳, 下載全部可選.
+ - 支援多線程下載
+ - 支援 cookie，支援下載 1080P
+ - 下載模式有僅下載最新一集，下載最新上傳，下載全部可選。
  - 自定義檢查更新間隔時間
  - 自定義番劇下載目錄
- - 自定義下載檔名前綴後綴及是否添加清晰度
- - 下載失敗, 下載過慢自動重啓任務
- - 支援使用FTP上傳至伺服器, 支援斷點續傳(適配Pure-Ftpd), 掉綫重傳, 支援 FTP over TLS
- - 檢查程序更新功能
+ - 自定義下載檔名前綴後綴及是否添加解析度
+ - 下載失敗，下載過慢自動重啟任務
+ - 支援使用 FTP 上傳至伺服器，支援斷點續傳（配合 Pure-Ftpd ），掉線重傳，支援 FTP over TLS
+ - 檢查程式更新功能
  - 支援新番分類
- - v6.0 開始支援cookie自動刷新
- - v7.0 開始支援使用(鏈式)代理
- - v9.0 開始支援記錄日志
+ - v6.0 開始支援 cookie 自動更新
+ - v7.0 開始支援使用（鏈式）代理
+ - v9.0 開始支援記錄日誌
  - v9.0 開始自動下載支援自定義番劇名
- - v16 支援向酷Q推送下載完成訊息
- - v16 支援将影片 metadata 前置, 此功能會在綫觀看时更快播放
- - v20 上綫Web控制面板
- - v20.2 支援命令行下載時同時下載彈幕(beta)
+ - v16 支援向 酷Q 推送下載完成訊息
+ - v16 支援將影片 metadata 前置，此功能會在線觀看時更快播放
+ - v20 上線 Web 控制面板
+ - v20.2 支援命令列下載時同時下載彈幕（beta）
 
 ## 任務列表
  - [x] 下載使用代理
- - [x] 使用ftp上傳至遠程伺服器
- - [x] Web控制臺(持續完善中)
+ - [x] 使用 ftp 上傳至遠程伺服器
+ - [x] Web 控制臺（持續完善中）
 
-## 配置説明
+## 設定説明
 
 ### config.json
 
-**config-sample.json**为范例配置文件, 可以将其修改后改名为**config.json**.
+**config-sample.json** 為範例設定檔案，可以將其修改後改名為 **config.json**。
 
-若不存在**config.json**, 则程序在运行时将会使用默认配置创建.
+若不存在 **config.json**，則程式在執行時將會使用預設設定建立。
 
 ```
 {
-    "bangumi_dir": "",  # 下載存放目錄, 動畫將會以番劇為單位分資料夾存放
-    "temp_dir": "",  # 臨時目錄位置, v9.0 開始下載中文件將會放在這裏, 完成後再轉移至番劇目錄, 留空默認在程序所在目錄的 temp 資料夾下
+    "bangumi_dir": "",  # 下載存放目錄，動畫將會以番劇為單位分資料夾存放
+    "temp_dir": "",  # 臨時目錄位置，v9.0 開始下載中文件將會放在這裏，完成後再轉移至番劇目錄，留空默認在程式所在目錄的 temp 資料夾下
     "classify_bangumi": true,  # 控制是否建立番劇資料夾
-    "check_frequency": 5,  # 檢查更新頻率, 單位為分鐘
-    "download_resolution": "1080",  # 下載選取清晰度, 若該清晰度不存在將會選取最近可用清晰度, 可選 360 480 540 576 720 1080
-    "lock_resolution": false,  # 鎖定清晰度, 如果指定清晰度不存在, 則放棄下載
+    "check_frequency": 5,  # 檢查更新頻率，單位為分鐘
+    "download_resolution": "1080",  # 下載選取解析度，若該解析度不存在將會選取最近可用解析度，可選 360 480 540 576 720 1080
+    "lock_resolution": false,  # 鎖定解析度，如果指定解析度不存在，則放棄下載
     "only_use_vip": false,  # 锁定 VIP 账号下载
-    "default_download_mode": "latest",  # 默認下載模式, 另一可選參數為 all 和 largest-sn. latest 為僅下載最後一集, all 下載番劇全部劇集, largest-sn 下載最近上傳的一集
-    "use_copyfile_method": false,  # 轉移影片至番劇資料夾時使用複製方法, 適用於保存到 rclone 掛載盤的情況
-    "multi-thread": 1,  # 最大并發下載數, 最高為 5, 超過將重置為 5
-    "multi_upload": 3,  # 最大并發上傳數
+    "default_download_mode": "latest",  # 默認下載模式，另一可選參數為 all 和 largest-sn. latest 為僅下載最後一集，all 下載番劇全部劇集，largest-sn 下載最近上傳的一集
+    "use_copyfile_method": false,  # 轉移影片至番劇資料夾時使用複製方法, 適用於儲存到 rclone 掛載盤的情況
+    "multi-thread": 1,  # 最大併發下載數, 最高為 5, 超過將重置為 5
+    "multi_upload": 3,  # 最大併發上傳數
     "segment_download_mode": true,  # 分段下載模式, 速度更快, 容錯率更高
     "segment_max_retry": 8,  # 在分段下載模式時有效, 每個分段最大重試次數, -1 為無限重試
-    "multi_downloading_segment": 3,  # 每個影片最大并發下載分段數, 僅在 "segment_download_mode" 為 true 時有效, 最高為 5, 超過將重置為 5
+    "multi_downloading_segment": 3,  # 每個影片最大併發下載分段數, 僅在 "segment_download_mode" 為 true 時有效, 最高為 5, 超過將重置為 5
     "add_bangumi_name_to_video_filename": true,  # 如果為 false, 則只有劇集名, 若劇集名為個位數字, 則補零
-    "add_resolution_to_video_filename": true,  # 是否在影片檔名中添加清晰度, 格式舉例: [1080P]
+    "add_resolution_to_video_filename": true,  # 是否在影片檔名中添加解析度, 格式舉例: [1080P]
     "customized_video_filename_prefix": "【動畫瘋】",  # 影片檔名前綴
-    "customized_bangumi_name_suffix": "",  # 影片檔名中番劇名的后缀, 在劇集名之前
+    "customized_bangumi_name_suffix": "",  # 影片檔名中番劇名的後缀, 在劇集名之前
     "customized_video_filename_suffix": "",  # 影片檔名後綴
     "video_filename_extension": "mp4",  # 影片檔副檔名, ts, mov, mkv 經過測試可以使用, 但 flv 不支援, 非 mp4 副檔名 faststart_movflags 將强制為 false
     "zerofill": 1,  # 劇集名補零, 填寫補足位數, 例: 填寫 2 劇集名為 01, 填寫 3 劇集名為 001
     "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Safari/537.36",  #  請求UA, 需要和獲取cookie的瀏覽器相同
     "use_proxy": false,  # 代理開關
-    "proxy": {"http://user:passwd@example.com:1000"},  # 代理配置
+    "proxy": {"http://user:passwd@example.com:1000"},  # 代理設定
     "upload_to_server": false,  # 上傳功能開關
-    "ftp": {  # FTP配置
+    "ftp": {  # FTP設定
         "server": "",  # FTP Server IP
         "port": "",  # 端口
         "user": "",  # 使用者名
         "pwd": "",  # 密碼
         "tls": true,  # 是否是 FTP over TLS
-        "cwd": "",  # 登陸後首先進入的目錄
-        "show_error_detail": false,  # 是否顯示細節錯誤信息
+        "cwd": "",  # 登入後首先進入的目錄
+        "show_error_detail": false,  # 是否顯示細節錯誤訊息
         "max_retry_num": 15  # 最大重傳數, 支援續傳
     },
-    "user_command": "shutdown -s -t 60"  # 命令行模式使用 -u 參數有效, 在命令行模式下完成所有任務后執行的命令
+    "user_command": "shutdown -s -t 60"  # 命令列模式使用 -u 參數有效, 在命令列模式下完成所有任務後執行的命令
     "coolq_notify": false,  # 是否向酷Q推送下載完成訊息
     "coolq_settings": {
         "msg_argument_name": "message",
@@ -191,139 +191,139 @@ docker run -td --name anigamerplus \
             "http://127.0.0.1:5700/send_group_msg?access_token=abc&group_id=87654321"
         ]
     },
-    "faststart_movflags": false,  # 是否將影片 metadata 前置, 啓用此功能時在綫觀看會更快播放, 僅在 video_filename_extension 為 mp4 時有效
+    "faststart_movflags": false,  # 是否將影片 metadata 前置, 啟用此功能時在線觀看會更快播放, 僅在 video_filename_extension 為 mp4 時有效
     "audio_language": false,  # 是否添加音軌標簽
     "use_mobile_api": false,  # 使用移動端API進行影片解析
     "check_latest_version": true,  # 是否檢查更新
-    "read_sn_list_when_checking_update": true,  # 是否在檢查更新時讀取sn_list.txt, 開啓後對sn_list.txt的更改將會在下次檢查更新時生效而不用重啓程序
-    "read_config_when_checking_update": true,  # 是否在檢查更新時讀取配置文件, 開啓後對配置文件的更改將會在下次檢查時更新生效而不用重啓程序
+    "read_sn_list_when_checking_update": true,  # 是否在檢查更新時讀取sn_list.txt, 開啟後對sn_list.txt的更改將會在下次檢查更新時生效而不用重啟程式
+    "read_config_when_checking_update": true,  # 是否在檢查更新時讀取設定文件, 開啟後對設定文件的更改將會在下次檢查時更新生效而不用重啟程式
     "ads_time": 25,  # 非VIP廣告等待時間, 如果等待時間不足, 程式會自行追加時間 (最大20秒)
     "mobile_ads_time":3  # 使用移動端API解析的廣告等待時間
     "use_dashboard": true  # Web 控制台開關
-    "dashboard": {  # Web控制面板配置
+    "dashboard": {  # Web控制面板設定
         "host": "127.0.0.1",  # 監聽地址, 如果需要允許外部訪問, 請填寫 "0.0.0.0"
         "port": 5000,  # 監聽端口
-        "SSL": false,  # 是否開啓SSL, 證書保存在 Dashboard\sslkey, 如果有需要可以自行替換證書
-        "BasicAuth": false,  # 是否使用 BasicAuth 進行認證, 注意, 用戶密碼是明文傳輸的, 如有需要建議同時啓用 SSL
+        "SSL": false,  # 是否開啟SSL, 證書儲存在 Dashboard\sslkey, 如果有需要可以自行替換證書
+        "BasicAuth": false,  # 是否使用 BasicAuth 進行認證, 注意, 用戶密碼是明文傳輸的, 如有需要建議同時啟用 SSL
         "username": "admin",  # BasicAuth 用戶名
         "password": "admin"  # BasicAuth 密碼
     },
     "save_logs": true,  # 是否記錄日志, 一天一個日志
     "quantity_of_logs": 7,  # 日志保留數量, 正整數值, 必須大於等於 1, 默認為 7
-    "config_version": 14.0,  # 配置文件版本
+    "config_version": 14.0,  # 設定文件版本
     "database_version": 2.0  # 資料庫版本
 }
 ```
 
-模式僅支援在 **latest**, **all**, **largest-sn** 三個中選一個, 錯詞及其他詞將會重置為**latest**模式
+模式僅支援在 **latest**, **all**, **largest-sn** 三個中選一個，錯詞及其他詞將會重置為 **latest** 模式
 
 ### 使用代理
-aniGamerPlus本身支援使用單個```http```或```https```或```socks5```(v12開始支援)代理.
+aniGamerPlus本身支援使用單個```http```或```https```或```socks5```(v12開始支援)代理。
 
-無密碼驗證的代理使用以下格式:
+無密碼驗證的代理使用以下格式：
 ```
 http://example.com:1000
 ```
 
-有密碼驗證的代理使用以下格式:
+有密碼驗證的代理使用以下格式：
 ```
 http://user:passwd@example.com:1000
 ```
 
-使用socks5代理支援遠端DNS, 配置時使用```socks5h```代替```socks5```, 如:
+使用 socks5 代理支援遠端 DNS，設定時使用```socks5h```代替```socks5```，如：
 ```
 socks5h://127.0.0.1:1483
 ```
 
-如果想使用其他的代理協議或使用鏈式代理, 需要下載 [**Gost**](https://github.com/ginuerzh/gost) 放置在系統PATH, 或本程序目錄下, 並命名爲 ```gost```, windows平臺為```gost.exe```
+如果想使用其他的代理協議或使用鏈式代理，需要下載 [**Gost**](https://github.com/ginuerzh/gost) 放置在系統 PATH，或本程式目錄下，並命名爲 ```gost```，windows 平臺為```gost.exe```
 
-若想使用鏈式代理, 請使用整數作爲 key, 代理出口將會是 key 最大的代理服務器.
+若想使用鏈式代理，請使用整數作爲 key，代理出口將會是 key 最大的代理服務器。
 
-Gost 支援 Shadowsocks 協議, 其實現是基於[shadowsocks-go](https://github.com/shadowsocks/shadowsocks-go), 目前僅支援這幾種加密方式: ```aes-128-cfb``` ```aes-192-cfb``` ```aes-256-cfb``` ```bf-cfb``` ```cast5-cfb``` ```des-cfb``` ```rc4-md5``` ```rc4-md5-6``` ```chacha20``` ```salsa20``` ```rc4``` ```table```
+Gost 支援 Shadowsocks 協議，其實現是基於 [shadowsocks-go](https://github.com/shadowsocks/shadowsocks-go) ，目前僅支援這幾種加密方式：```aes-128-cfb``` ```aes-192-cfb``` ```aes-256-cfb``` ```bf-cfb``` ```cast5-cfb``` ```des-cfb``` ```rc4-md5``` ```rc4-md5-6``` ```chacha20``` ```salsa20``` ```rc4``` ```table```
 
-**注意: ```read_config_when_checking_update``` 配置對代理配置無效**
+**注意：```read_config_when_checking_update``` 設定對代理設定無效**
 
 **使用代理建議使用分段下載模式**
 
-**如果代理網路不穩定, 建議```multi-thread```配置為```1```**
+**如果代理網路不穩定，建議```multi-thread```設定為```1```**
 
 ### 下載模式説明
 
-v8.0 影片下載模式新增分段下載, 其工作流程: 由 aniGamerPlus 讀取 m3u8 文件, 下載 key 及所有影片分段至臨時資料夾, 再使用 ffmpeg 解密合并.
+v8.0 影片下載模式新增分段下載，其工作流程：由 aniGamerPlus 讀取 m3u8 文件，下載 key 及所有影片分段至臨時資料夾，再使用 ffmpeg 解密合併。
 
 **分段下載模式特點:**
 
 - 分段下載模式速度更快
-- 個別分段下載失敗會自動重試, 最多重試8次
-- aniGamerPlus本身消耗的記憶體將略高於舊下載模式
-- aniGamerPlus本身性能消耗將會略高
-- 短時間内(解密合并階段)將會占用2倍影片大小的磁盤空間
-- 命令行模式下下載單個視頻時, 實時顯示已下載分段數占總分段數百分比
+- 個別分段下載失敗會自動重試，最多重試 8 次
+- aniGamerPlus 本身消耗的記憶體將略高於舊下載模式
+- aniGamerPlus 本身性能消耗將會略高
+- 短時間内（解密合併階段）將會占用2倍影片大小的磁盤空間
+- 命令列模式下下載單個影片時，實時顯示已下載分段數占總分段數百分比
 
-舊下載模式, 即 ffmpeg 下載模式的工作流程: 直接將 m3u8 文件交給 ffmpeg, 下載解密合并全由 ffmpeg 完成.
+舊下載模式，即 ffmpeg 下載模式的工作流程：直接將 m3u8 文件交給 ffmpeg，下載解密合併全由 ffmpeg 完成。
 
-**ffmpeg下載模式特點:**
+**ffmpeg下載模式特點：**
 
 - 一個分段下載失敗即判斷爲下載失敗
 - 在下載過程中可能出現 ffmpeg 卡死的情況
 - 不會生成臨時資料夾
-- 命令行模式下下載單個視頻時, 實時顯示已下載的大小
+- 命令列模式下下載單個影片時，實時顯示已下載的大小
 
 
-除非你通往動畫瘋的網路足夠穩, 否則建議使用分段下載模式, 配置 ```segment_download_mode``` 為 ```true``` 開啓分段下載模式
+除非你通往動畫瘋的網路足夠穩，否則建議使用分段下載模式，設定 ```segment_download_mode``` 為 ```true``` 開啟分段下載模式
 
-儅開啓分段下載模式時, 配置 ```multi_downloading_segment``` 將有效, 這個值指定一個影片同時最多下載幾個分段, 一般設定在```3```左右速度就足夠快了
+儅開啟分段下載模式時，設定 ```multi_downloading_segment``` 將有效，這個值指定一個影片同時最多下載幾個分段，一般設定在```3```左右速度就足夠快了
 
 ### cookie.txt
 
-1.  使用者cookie文件, 將瀏覽器的cookie字段複製, 以**cookie.txt**為檔名保存在程序目錄下
-2.  將獲取cookie的瀏覽器UA, 写入```config.json```的```ua```項目
+1.  使用者 cookie 文件，將瀏覽器的 cookie 字段複製，以 **cookie.txt** 為檔名儲存在程式目錄下
+2.  將獲取 cookie 的瀏覽器 UA，寫入```config.json```的```ua```項目
 
-**v6.0版本開始支援自動刷新cookie, 爲了不與正常使用的cookie衝突, 請從使用瀏覽器的無痕模式取得僅供aniGamerPlus使用的cookie**
+**v6.0 版本開始支援自動更新 cookie，爲了不與正常使用的 cookie 衝突，請從使用瀏覽器的無痕模式取得僅供 aniGamerPlus 使用的 cookie**
 
-取得cookie后, 登陸狀態會顯示在 **https://home.gamer.com.tw/login_devices.php** , 你可以從這裏點擊```退出```來失效你的cookie, 其顯示的信息來自與你取得cookie的瀏覽器(UA)
+取得 cookie 後，登入狀態會顯示在 **https://home.gamer.com.tw/login_devices.php** ，你可以從這裏點擊```登出```來讓你的 cookie 失效，其顯示的訊息來自與你取得 cookie 的瀏覽器（UA）
 
-使用cookie后所抓取的影片記錄會記錄在你的[觀看紀錄](https://ani.gamer.com.tw/viewList.php)中
+使用 cookie 後所抓取的影片記錄會記錄在你的 [觀看紀錄](https://ani.gamer.com.tw/viewList.php) 中
 
-:warning: **登陸時請勾選"保持登入狀態"**
+:warning: **登入時請勾選 "保持登入狀態"**
 
-#### 使用Chrome舉例如何獲取 Cookie:
+#### 使用Chrome舉例如何獲取 Cookie：
 
- - 開啓Chrome的**無痕模式**, 登陸動畫瘋, 記得勾選**保持登入狀態**
+ - 開啟 Chrome的**無痕模式**，登入動畫瘋，記得勾選**保持登入狀態**
 
- - 按 F12 調出開發者工具, 前往動畫瘋首頁, 切換到 Network 標簽, 在下方選中 "ani.gamer.com.tw" 在右側即可看到 Cookie, 如圖:
+ - 按 F12 叫出開發者工具，前往動畫瘋首頁，切換到 Network 分頁，在下方選中 `"ani.gamer.com.tw"` 在右側即可看到 Cookie，如圖：
     ![](screenshot/WhereIsCookie.png)
 
- - 在程序所在目錄新建一個名爲**cookie.txt**的文本文件, 打開將上面的Cookie複製貼上保存即可
+ - 在程式所在目錄新建一個名爲**cookie.txt**的文字檔案，打開將上面的 Cookie 複製貼上儲存即可
     ![](screenshot/CookiesFormat.png)
 
-#### 使用Chrome舉例如何獲取 UA:
+#### 使用Chrome舉例如何獲取 UA：
 
- - 訪問 **https://developers.whatismybrowser.com/useragents/parse/?analyse-my-user-agent=yes** 即可查看該瀏覽器 UA
- - 如果此網址失效，以下為可查詢UA的備用網址：
+ - 瀏覽 **https://developers.whatismybrowser.com/useragents/parse/?analyse-my-user-agent=yes** 即可查看該瀏覽器 UA
+ - 如果此網址失效，以下為可查詢 UA 的備用網址：
     - https://www.whatsmyua.info/
     - http://service.spiritsoft.cn/ua.html
     ![](screenshot/how_to_get_my_ua.png)
 
- - 將 UA 複製粘貼到```config.json```的```ua```項目
+ - 將 UA 複製貼上到```config.json```的 ```ua``` 選項
     ![](screenshot/how_to_use_my_ua.png)
 
 ### sn_list.txt
 
-需要自動下載的番劇列表,一個番劇中選任一sn填入即可
+需要自動下載的番劇列表，一個番劇中選任一 sn 填入即可
 
-可以對個別番劇配置下載模式, 未配置下載模式將會使用**config.json**定義的默認下載模式
+可以對個別番劇設定下載模式，未設定下載模式將會使用 **config.json** 定義的默認下載模式
 
-支援注釋 **#** 後面的所有字符程序均不會讀取, 可以標記番劇名
+支援注釋 **#** 後面的所有字符程式均不會讀取，可以標記番劇名
 
-模式僅支援在 **latest**, **all**, **largest-sn** 三個中選一個, 錯詞及其他詞將會重置為**config.json**中定義的默認下載模式
+模式僅支援在 **latest**, **all**, **largest-sn** 三個中選一個，錯詞及其他詞將會重置為 **config.json** 中定義的默認下載模式
 
-格式:
+格式：
 ```
 sn碼 下載模式(可空) #注釋(可空)
 ```
 
-範例:
+範例：
 ```
 10147 all # 前進吧！登山少女 第三季 [1]
 11285 # 關於我轉生變成史萊姆這檔事
@@ -332,11 +332,11 @@ sn碼 下載模式(可空) #注釋(可空)
 11317 lastest # SSSS.GRIDMAN
 ```
 
-自v6.0開始, 新增對番劇進行分類功能, 在一排番劇列表的上方 **@** 開頭後面的字符將會作爲番劇的分類名, 番劇會歸類在此分類名的資料夾下
+自 v6.0 開始，新增對番劇進行分類功能，在一排番劇列表的上方 **@** 開頭後面的字符將會作爲番劇的分類名，番劇會歸類在此分類名的資料夾下
 
 若單獨 **@** 表示不分類
 
-範例:
+範例：
 ```
 @2019一月番
 11433 # ENDRO！
@@ -346,13 +346,13 @@ sn碼 下載模式(可空) #注釋(可空)
 @
 11468 # 動物朋友
 ```
-上面表示將會把**ENDRO**和**上野**放在**2019一月番**資料夾裏, 將**刀劍**放在**2019十月番**資料夾裏, **動物朋友** 不分類, 直接放在番劇目錄下
+上面表示將會把 **ENDRO** 和 **上野** 放在 **2019一月番** 資料夾裏，將 **刀劍** 放在 **2019十月番** 資料夾裏，**動物朋友** 不分類, 直接放在番劇目錄下
 
-自 v9.0 開始, 支援重命名番劇, 在注釋之前, 模式之後, 用 ```<``` 與 ```>``` 將自定義的番劇名框起來, 下載時將會使用這個名字作爲番劇目錄名
+自 v9.0 開始，支援重命名番劇，在注釋之前，模式之後，用 ```<``` 與 ```>``` 將自定義的番劇名框起來，下載時將會使用這個名字作爲番劇目錄名
 
-PS: 連續多個空格將會被替換爲單個空格, 和模式需要間隔一個空格
+PS：連續多個空格將會被替換爲單個空格, 和模式需要間隔一個空格
 
-範例:
+範例：
 ```
 11415 <魔法少女特殊战明日香> # 魔法少女特殊戰明日香
 11433 <えんどろ～！> # ENDRO！
@@ -362,40 +362,40 @@ PS: 連續多個空格將會被替換爲單個空格, 和模式需要間隔一�
 
 ### aniGamer.db
 
-sqlite3資料庫, 可以使用 [SQLite Expert](http://www.sqliteexpert.com/) 等工具打開編輯
+sqlite3 資料庫，可以使用 [SQLite Expert](http://www.sqliteexpert.com/) 等工具打開編輯
 
-記錄視頻下載狀態等相關信息, 一般無需改動
+記錄影片下載狀態等相關訊息，一般無需更改
 
-欄位設計:
-- ```sn``` sn值 (PK)
+欄位設計：
+- ```sn``` sn 值（PK）
 - ```title``` 完整標題
 - ```anime_name``` 番劇名
-- ```episode``` 劇集名, 一般爲數字, 也可能是```特別篇``` ```電影``` 等
-- ```status``` 下載狀態, ```0``` 為未成功下載, ```1``` 為已成功下載
-- ```remote_status``` 上傳状态, ```0``` 為未成功上傳, ```1``` 為已成功上傳
+- ```episode``` 劇集名，一般爲數字，也可能是```特別篇``` ```電影``` 等
+- ```status``` 下載狀態，```0``` 為未成功下載，```1``` 為已成功下載
+- ```remote_status``` 上傳狀態，```0``` 為未成功上傳，```1``` 為已成功上傳
 - ```resolution``` 下載的影片檔解析度
-- ```file_size``` 影片檔大小, 整數, 單位MB
+- ```file_size``` 影片檔大小，整數，單位 MB
 - ```local_file_path``` 影片檔路徑
-- ```CreatedTime``` 資料創建時間
+- ```CreatedTime``` 資料建立時間
 
-截图:
+截圖：
 ![](screenshot/db.png)
 
 
-## 命令行使用
+## 命令列使用
 
-支援命令行使用, 文件默認將保存在**config.json**中指定的目錄下
+支援命令列使用，檔案默認將儲存在**config.json**中指定的目錄下
 
-**配置文件中的代理配置同樣適用於命令行模式!**
+**設定文件中的代理設定同樣適用於命令列模式！**
 
-**除了使用 list 模式的情況, 命令行模式將不會和資料庫進行交互, 將會無視數據庫中下載狀態標記强制下載**
+**除了使用 list 模式的情況，命令列模式將不會和資料庫進行交互，將會無視數據庫中下載狀態標記強制下載**
 
-**EXE 檔的 aniGamerPlus.exe 也是支援命令行使用的, 將下方演示的 ```python3 aniGamerPlus.py``` 換成 ```aniGamerPlus``` 就行**
+**EXE 檔的 aniGamerPlus.exe 也是支援命令列使用的，將下方展示的 ```python3 aniGamerPlus.py``` 換成 ```aniGamerPlus``` 就行**
 
-參數:
+參數：
 ```
 >python3 aniGamerPlus.py -h
-當前aniGamerPlus版本: v21.0
+當前 aniGamerPlus版本：v21.0
 usage: aniGamerPlus.py [-h] [--sn SN]
                        [--resolution {360,480,540,576,720,1080}]
                        [--download_mode {single,latest,largest-sn,multi,all,range,list,sn-list,sn-range}]
@@ -405,139 +405,139 @@ usage: aniGamerPlus.py [-h] [--sn SN]
 
 optional arguments:
   -h, --help            show this help message and exit
-  --sn SN, -s SN        視頻sn碼(數字)
+  --sn SN, -s SN        影片 sn 碼（數字）
   --resolution {360,480,540,576,720,1080}, -r {360,480,540,576,720,1080}
-                        指定下載清晰度(數字)
+                        指定下載解析度（數字）
   --download_mode {single,latest,largest-sn,multi,all,range,list,sn-list,sn-range}, -m {single,latest,largest-sn,multi,all,range,list,sn-list,sn-range}
                         下載模式
   --thread_limit THREAD_LIMIT, -t THREAD_LIMIT
-                        最高并發下載數(數字)
+                        最高併發下載數（數字）
   --current_path, -c    下載到當前工作目錄
   --episodes EPISODES, -e EPISODES
                         僅下載指定劇集
   --no_classify, -n     不建立番劇資料夾
   --information_only, -i
                         僅查詢資訊
-  --user_command, -u    所有下載完成后執行用戶命令
+  --user_command, -u    所有下載完成後執行用戶命令
   --danmu, -d           以 .ass 下載彈幕(beta)
 ```
 
- - **-s** 接要下載視頻的sn碼,不可空
+ - **-s** 接要下載影片的 sn 碼，不可空
 
- - **-r** 接要下載的清晰度, 可空, 空則讀取**config.json**中的定義, 不存在則選取最近可用清晰度
+ - **-r** 接要下載的解析度，可空，空則讀取 **config.json** 中的定義，不存在則選取最近可用解析度
 
- - **-m** 接下載模式, 可空, 空則下載傳入sn碼的視頻
+ - **-m** 接下載模式，可空，空則下載傳入 sn 碼的影片
 
-    - **single** 下載此 sn 單集(默認)
+    - **single** 下載此 sn 單集（默認）
 
-    - **multi** 下載多個sn, 啓用此模式時, 通過```-e```傳入多個sn, sn之間使用英文```,```分割
+    - **multi** 下載多個sn，啟用此模式時，透過```-e```傳入多個 sn，sn 之間使用英文```,```分割
 
     - **all** 下載此番劇所有劇集
 
-    - **latest** 下載此番劇最後一集(即網頁上顯示排最後的一集)
+    - **latest** 下載此番劇最後一集（即網頁上顯示排最後的一集）
 
-    - **largest-sn** 下載此番劇最近上傳的一集(即sn最大的一集)
+    - **largest-sn** 下載此番劇最近上傳的一集（即 sn 最大的一集）
 
     - **range** 下載此番指定的劇集
 
-    - **list** 讀取 sn_list 中的内容進行下載, 並會將任務狀態記錄在資料庫中, 重啓自動下載未完成的集數, 該功能用於單次大量下載. **此模式無法通過```-r```參數指定解析度**
+    - **list** 讀取 sn_list 中的内容進行下載，並會將任務狀態記錄在資料庫中，重啟自動下載未完成的集數，該功能用於單次大量下載。 **此模式無法通過```-r```參數指定解析度**
 
-    - **sn-list** 讀取 sn_list 中的指定sn進行下載, sn後面的模式設定會被忽略，僅下載單個sn, 並會將任務狀態記錄在資料庫中. **此模式無法通過```-r```參數指定解析度**
+    - **sn-list** 讀取 sn_list 中的指定sn進行下載，sn後面的模式設定會被忽略，僅下載單個sn，並會將任務狀態記錄在資料庫中。 **此模式無法通過```-r```參數指定解析度**
     
-    - **sn-range** 下載此番据指定sn範圍的劇集, 對於劇集名稱不是正整數的番劇, 可以用此模式
+    - **sn-range** 下載此番據指定 sn 範圍的劇集，對於劇集名稱不是正整數的番劇，可以用此模式
 
- - **-t** 接最大并發下載數, 可空, 空則讀取**config.json**中的定義
+ - **-t** 接最大併發下載數，可空，空則讀取**config.json**中的定義
 
- - **-c** 開關, 指定時將會下載到當前工作路徑下
+ - **-c** 開關，指定時將會下載到當前工作路徑下
 
  - **-n** 不建立番劇資料夾
 
- - **-i** 僅顯示影片資訊, 當爲```list```模式時, 會獲取 sn_list 中的單個 sn 的資訊.
+ - **-i** 僅顯示影片資訊，當爲```list```模式時，會獲取 sn_list 中的單個 sn 的資訊。
 
- - **-u** 所有任務完成后執行使用者命令 (配置在```config.json```的```user_command```中),  用於實現下載完成后關機等操作
+ - **-u** 所有任務完成後執行使用者命令（設定在```config.json```的```user_command```中），用於實現下載完成後關機等操作
 
  - **-d** 下載 .ass 彈幕(beta)，推薦使用 XySubFilter 進行字幕渲染
 
  - **-e**
-    - **在 ```range``` 模式下, 下載此番劇指定劇集, 支援範圍輸入, 支援多個不連續聚集下載, 僅支援整數命名的劇集**
+    - **在 ```range``` 模式下，下載此番劇指定劇集，支援範圍輸入，支援多個不連續聚集下載，僅支援整數命名的劇集**
 
-    - **在 ```multi``` 模式下, 用於指定多個sn**
+    - **在 ```multi``` 模式下，用於指定多個 sn**
 
-    - ```-e``` 參數優先于 ```-m``` 參數, 若使用 ```-e``` 參數時不指定模式, 則默認為 ```range``` 模式
+    - ```-e``` 參數優先於 ```-m``` 參數，若使用 ```-e``` 參數時不指定模式，則默認為 ```range``` 模式
 
     - 若使用 ```-m range``` 則必須使用 ```-e``` 指定需要下載的劇集
 
-    - 在 ```range``` 模式下, 若指定了不存在的劇集會警告並跳過, 僅下載存在的劇集
+    - 在 ```range``` 模式下，若指定了不存在的劇集會警告並跳過，僅下載存在的劇集
 
-    - 指定不連續劇集或sn時, 請用英文逗號```,```分隔, 中間無空格
+    - 指定不連續劇集或 sn 時，請用英文逗號```,```分隔，中間無空格
 
-    - 在 ```range``` 模式下, 指定連續劇集格式: 起始劇集-終止劇集. 舉例想下載第5到9集, 則格式為 5-9
+    - 在 ```range``` 模式下，指定連續劇集格式：起始劇集-終止劇集。舉例想下載第 5 到 9 集，則格式為 5-9
     
-    - 在 ```sn-range``` 模式下, 格式同 ```range``` 模式, 不過將劇集改成 sn 碼
+    - 在 ```sn-range``` 模式下，格式同 ```range``` 模式，不過將劇集改成 sn 碼
 
-    - 將會按sn順序下載
+    - 將會按 sn 順序下載
 
-    - 舉例:
+    - 舉例：
 
-        - 想下載某番劇第1,2,3集
+        - 想下載某番劇第 1 ,2 ,3 集
         ```python3 aniGamerPlus.py -s 10218 -e 1,2,3```
 
-        - 想下載某番劇第5到8集
+        - 想下載某番劇第 5 到 8 集
         ```python3 aniGamerPlus.py -s 10218 -e 5-8```
 
-        - 想下載某番劇第2集, 第5到8集, 第12集
+        - 想下載某番劇第 2 集，第 5 到 8 集，第 12 集
         ```python3 aniGamerPlus.py -s 10218 -e 2,5-8,12```
         
-        - 想下載某番劇sn範圍 14440 到 14459 的劇集, 外加 sn 為 14670 和 14746 的兩集
+        - 想下載某番劇 sn 範圍 14440 到 14459 的劇集，外加 sn 為 14670 和 14746 的兩集
         ```python3 aniGamerPlus.py -s 14440 -m sn-range -e 14670,14746,14440-14459```
 
-        - 想下載sn為 14479,14518,14511 的動畫
+        - 想下載 sn 為 14479, 14518, 14511 的動畫
         ```aniGamerPlus.py -m multi -e 14479,14518,14511```
 
-    - 截圖:
+    - 截圖：
 
         ![](screenshot/cui_range_mode.png)
 
         ![](screenshot/cui_range_mode_err.png)
 
-        在Android中使用 (使用Termux)
+        在 Android 中使用（使用Termux）
 
         ![](screenshot/cui_on_android.jpg)
 
 ## Dashboard
 
-在 v20 版本首次啓用了 Web 控制臺, 相關配置在 ```config.json``` 的 ```dashboard``` 項目中.
+在 v20 版本首次啟用了 Web 控制臺，相關設定在 ```config.json``` 的 ```dashboard``` 項目中。
 
-Web 控制臺默認啓用, 默認端口 5000, 支援 SSL (https), 證書保存在 Dashboard\sslkey, 如果有需要可以自行替換證書.
+Web 控制臺默認啟用，默認端口 5000，支援 SSL（https），證書儲存在 Dashboard/sslkey，如果有需要可以自行替換證書。
 
-如果想開放外部訪問, 可以將 ```dashboard``` 配置中的 ```host``` 設置成 ```0.0.0.0```
+如果想開放外部訪問，可以將 ```dashboard``` 設定中的 ```host``` 設置成 ```0.0.0.0```
 
-支援使用 BasicAuth 進行認證, **注意**:warning: **用戶密碼是明文傳輸的, 如有需要建議同時啓用 SSL**.
+支援使用 BasicAuth 進行認證，**注意**:warning: **用戶密碼是明文傳輸的, 如有需要建議同時啟用 SSL**。
 
-支援在 Web 控制臺下達手動任務(即命令行模式啓動的任務), 爲了控制臺輸出工整, 控制臺不會顯示下載進度.
+支援在 Web 控制臺下達手動任務（即命令列模式啟動的任務），爲了控制臺輸出工整，控制臺不會顯示下載進度。
 
-**目前控制臺僅能配置部分主要配置, 另外Web任務進度顯示等其他擴展功能正在銳意製作中……**
+**目前控制臺僅能設定部分主要設定，另外 Web 任務進度顯示等其他擴充功能正在銳意製作中……**
 
-相關配置:
+相關設定：
 ```
 "use_dashboard": true  # Web 控制台開關
-# Web控制面板配置
+# Web 控制面板設定
 "dashboard": {
-    "host": "127.0.0.1",  # 監聽地址, 如果需要允許外部訪問, 請填寫 "0.0.0.0"
+    "host": "127.0.0.1",  # 監聽地址，如果需要允許外部訪問，請填寫 "0.0.0.0"
     "port": 5000,  # 監聽端口
-    "SSL": false,  # 是否開啓SSL
+    "SSL": false,  # 是否開啟SSL
     "BasicAuth": false,  # 是否使用 BasicAuth 進行認證
     "username": "admin",  # BasicAuth 用戶名
     "password": "admin"  # BasicAuth 密碼
 }
 ```
 
-Web控制臺截圖:
- - 主界面:
+Web 控制臺截圖：
+ - 主界面：
     ![](screenshot/Dashboard_UI.png)
- - 手動任務:
+ - 手動任務：
     ![](screenshot/Dashboard_manualTask.png)
- - 在綫編輯 sn_list
+ - 在線編輯 sn_list
     ![](screenshot/Dashboard_sn_list.png)
- - 控制臺輸出:
+ - 控制臺輸出：
     ![](screenshot/Dashboard_Console.png)

--- a/aniGamerPlus.py
+++ b/aniGamerPlus.py
@@ -38,7 +38,7 @@ def port_is_available(port):
 def gost_port():
     random_port = random.randint(40000, 60000)
     while not port_is_available(random_port):
-        # 如果该端口不可用
+        # 如果該埠不可用
         random_port = random.randint(40000, 60000)
     return random_port
 
@@ -47,7 +47,7 @@ def build_anime(sn):
     anime = {'anime': None, 'failed': True}
     try:
         if settings['use_gost']:
-            # 如果使用 gost, 则随机一个 gost 监听端口
+            # 如果使用 gost，則隨機一個 gost 監聽埠
             anime['anime'] = Anime(sn, gost_port=gost_port)
         else:
             anime['anime'] = Anime(sn)
@@ -57,16 +57,16 @@ def build_anime(sn):
             anime['anime'].enable_danmu()
 
     except TryTooManyTimeError:
-        err_print(sn, '抓取失敗', '影片信息抓取失敗!', status=1)
+        err_print(sn, '抓取失敗', '影片資訊抓取失敗！', status=1)
     except BaseException as e:
-        err_print(sn, '抓取失敗', '抓取影片信息時發生未知錯誤: '+str(e), status=1)
-        err_print(sn, '抓取異常', '異常詳情:\n'+traceback.format_exc(), status=1, display=False)
+        err_print(sn, '抓取失敗', '抓取影片資訊時發生未知錯誤: ' + str(e), status=1)
+        err_print(sn, '抓取異常', '異常詳情:\n' + traceback.format_exc(), status=1, display=False)
     return anime
 
 
 def read_db(sn):
     db_locker.acquire()
-    # 传入sn(int)，读取该 sn 资料，返回 dict
+    # 傳入sn(int)，讀取該 sn 資料，返回 dict
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
 
@@ -97,7 +97,7 @@ def read_db(sn):
 
 def insert_db(anime):
     db_locker.acquire()
-    # 向数据库插入新资料
+    # 向資料庫插入新資料
     anime_dict = {'sn': str(anime.get_sn()),
                   'title': anime.get_title(),
                   'anime_name': anime.get_bangumi_name(),
@@ -110,7 +110,7 @@ def insert_db(anime):
         cursor.execute("INSERT INTO anime (sn, title, anime_name, episode) VALUES (:sn, :title, :anime_name, :episode)",
                        anime_dict)
     except sqlite3.IntegrityError as e:
-        err_print(anime_dict['sn'], 'ＤＢ错误', 'title=' + anime_dict['title'] + ' 数据已存在！' + str(e), status=1)
+        err_print(anime_dict['sn'], '資料庫錯誤', 'title=' + anime_dict['title'] + ' 資料已存在！' + str(e), status=1)
 
     cursor.close()
     conn.commit()
@@ -120,12 +120,12 @@ def insert_db(anime):
 
 def update_db(anime):
     db_locker.acquire()
-    # 更新数据库 status, resolution, file_size 资料
+    # 更新資料庫 status, resolution, file_size 資料
     anime_dict = {}
     if anime.video_size > 5:
         anime_dict['status'] = 1
     else:
-        # 下载失败
+        # 下載失敗
         anime_dict['status'] = 0
 
     if anime.upload_succeed_flag:
@@ -172,54 +172,54 @@ def worker(sn, sn_info, realtime_show_file_size=False):
     def upload_quit():
         queue.pop(sn)
         processing_queue.remove(sn)
-        upload_limiter.release()  # 并发上传限制器
+        upload_limiter.release()  # 併發上傳限制器
         sys.exit(0)
 
     anime_in_db = read_db(sn)
-    # 如果用户设定要上传且已经下载好了但还没有上传成功, 那么仅上传
+    # 如果使用者設定要上傳且已經下載好了但還沒有上傳成功, 那麼僅上傳
     if settings['upload_to_server'] and anime_in_db['status'] == 1 and anime_in_db['remote_status'] == 0:
-        upload_limiter.acquire()  # 并发上传限制器
+        upload_limiter.acquire()  # 併發上傳限制器
         anime = build_anime(sn)
         if anime['failed']:
-            err_print(sn, '任务失敗', '從任務列隊中移除, 等待下次更新重試.', status=1)
+            err_print(sn, '任務失敗', '從任務列隊中移除, 等待下次更新重試.', status=1)
             upload_quit()
 
-        # 视频信息抓取成功
+        # 影片資訊抓取成功
         anime = anime['anime']
         if not os.path.exists(anime_in_db['local_file_path']):
-            # 如果数据库中记录的文件路径已失效
+            # 如果資料庫中記錄的檔案路徑已失效
             update_db(anime)
-            err_msg_detail = 'title=\"' + anime.get_title() + '\" 本地文件丢失, 從任務列隊中移除, 等待下次更新重試.'
-            err_print(sn, '上传失敗', err_msg_detail, status=1)
+            err_msg_detail = 'title=\"' + anime.get_title() + '\" 本地檔案丟失, 從任務列隊中移除, 等待下次更新重試.'
+            err_print(sn, '上傳失敗', err_msg_detail, status=1)
             upload_quit()
 
-        anime.local_video_path = anime_in_db['local_file_path']  # 告知文件位置
-        anime.video_size = anime_in_db['file_size']  # 通過 update_db() 下载状态检查
-        anime.video_resolution = anime_in_db['resolution']  # 避免更新时把分辨率变成0
+        anime.local_video_path = anime_in_db['local_file_path']  # 告知檔案位置
+        anime.video_size = anime_in_db['file_size']  # 透過 update_db() 下載狀態檢查
+        anime.video_resolution = anime_in_db['resolution']  # 避免更新時把解析度變成0
 
         try:
-            if not anime.upload(bangumi_tag):  # 如果上传失败
-                err_msg_detail = 'title=\"' + anime.get_title() + '\" 從任務列隊中移除, 等待下次更新重試.'
-                err_print(sn, '上传失敗', err_msg_detail, 1)
+            if not anime.upload(bangumi_tag):  # 如果上傳失敗
+                err_msg_detail = 'title=\"' + anime.get_title() + '\" 從任務列隊中移除，等待下次更新重試。'
+                err_print(sn, '上傳失敗', err_msg_detail, 1)
             else:
                 update_db(anime)
                 err_print(sn, '任務完成', status=2)
         except BaseException as e:
-            err_msg_detail = 'title=\"' + anime.get_title() + '\" 發生未知錯誤, 等待下次更新重試: ' + str(e)
+            err_msg_detail = 'title=\"' + anime.get_title() + '\" 發生未知錯誤，等待下次更新重試：' + str(e)
             err_print(sn, '上傳失敗', '異常詳情:\n'+traceback.format_exc(), status=1, display=False)
             err_print(sn, '上傳失敗', err_msg_detail, 1)
 
         upload_quit()
 
-    # =====下载模块 =====
-    thread_limiter.acquire()  # 并发下载限制器
+    # ===== 下載模組 =====
+    thread_limiter.acquire()  # 併發下載限制器
     anime = build_anime(sn)
 
     if anime['failed']:
         queue.pop(sn)
         processing_queue.remove(sn)
         thread_limiter.release()
-        err_print(sn, '任务失敗', '從任務列隊中移除, 等待下次更新重試.', status=1)
+        err_print(sn, '任務失敗', '從任務列隊中移除，等待下次更新重試。', status=1)
         sys.exit(1)
 
     anime = anime['anime']
@@ -228,9 +228,9 @@ def worker(sn, sn_info, realtime_show_file_size=False):
         anime.download(settings['download_resolution'], bangumi_tag=bangumi_tag, rename=rename,
                        realtime_show_file_size=realtime_show_file_size, classify=settings['classify_bangumi'])
     except BaseException as e:
-        # 兜一下各种奇奇怪怪的错误
-        err_print(sn, '下載異常', '發生未知錯誤: '+str(e), status=1)
-        err_print(sn, '下載異常', '異常詳情:\n'+traceback.format_exc(), status=1, display=False)
+        # 兜一下各種奇奇怪怪的錯誤
+        err_print(sn, '下載異常', '發生未知錯誤: ' + str(e), status=1)
+        err_print(sn, '下載異常', '異常詳情:\n' + traceback.format_exc(), status=1, display=False)
         anime.video_size = 0
 
     if anime.video_size < 5:
@@ -238,34 +238,34 @@ def worker(sn, sn_info, realtime_show_file_size=False):
         queue.pop(sn)
         processing_queue.remove(sn)
         thread_limiter.release()
-        err_msg_detail = 'title=\"' + anime.get_title() + '\" 從任務列隊中移除, 等待下次更新重試.'
-        err_print(sn, '任务失敗', err_msg_detail, status=1)
+        err_msg_detail = 'title=\"' + anime.get_title() + '\" 從任務列隊中移除，等待下次更新重試。'
+        err_print(sn, '任務失敗', err_msg_detail, status=1)
         if int(sn) in Config.tasks_progress_rate.keys():
-            del Config.tasks_progress_rate[int(sn)]  # 任务失败, 不在监控此任务进度
+            del Config.tasks_progress_rate[int(sn)]  # 任務失敗，不在監控此任務進度
         sys.exit(1)
 
-    update_db(anime)  # 下载完成后, 更新数据库
-    thread_limiter.release()  # 并发下载限制器
-    # =====下载模块结束 =====
+    update_db(anime)  # 下載完成後，更新資料庫
+    thread_limiter.release()  # 併發下載限制器
+    # ===== 下载模組結束 =====
 
-    # =====上传模块=====
+    # ===== 上傳模組 =====
     if settings['upload_to_server']:
-        upload_limiter.acquire()  # 并发上传限制器
+        upload_limiter.acquire()  # 併發上傳限制器
 
         try:
-            anime.upload(bangumi_tag)  # 上传至服务器
+            anime.upload(bangumi_tag)  # 上傳至伺服器
         except BaseException as e:
-            # 兜一下各种奇奇怪怪的错误
-            err_print(sn, '上傳異常', '發生未知錯誤, 從任務列隊中移除, 等待下次更新重試: ' + str(e), status=1)
-            err_print(sn, '上傳異常', '異常詳情:\n'+traceback.format_exc(), status=1, display=False)
+            # 兜一下各種奇奇怪怪的錯誤
+            err_print(sn, '上傳異常', '發生未知錯誤，從任務列隊中移除，等待下次更新重試：' + str(e), status=1)
+            err_print(sn, '上傳異常', '異常詳情:\n' + traceback.format_exc(), status=1, display=False)
             upload_quit()
 
-        update_db(anime)  # 上传完成后, 更新数据库
-        upload_limiter.release()  # 并发上传限制器
-    # =====上传模块结束=====
+        update_db(anime)  # 上傳完成後, 更新資料庫
+        upload_limiter.release()  # 併發上傳限制器
+        # =====上傳模組結束=====
 
-    queue.pop(sn)  # 从任务列队中移除
-    processing_queue.remove(sn)  # 从当前任务列队中移除
+    queue.pop(sn)  # 從任務列隊中移除
+    processing_queue.remove(sn)  # 從當前任務列隊中移除
     err_print(sn, '任務完成', status=2)
 
 
@@ -273,55 +273,55 @@ def check_tasks():
     for sn in sn_dict.keys():
         anime = build_anime(sn)
         if anime['failed']:
-            err_print(sn, '更新狀態', '檢查更新失敗, 跳過等待下次檢查', status=1)
+            err_print(sn, '更新狀態', '檢查更新失敗，跳過等待下次檢查', status=1)
             continue
         anime = anime['anime']
         err_print(sn, '更新資訊', '正在檢查《' + anime.get_bangumi_name() + '》')
         episode_list = list(anime.get_episode_list().values())
 
         if sn_dict[sn]['mode'] == 'all':
-            # 如果用户选择全部下载 download_mode = 'all'
-            for ep in episode_list:  # 遍历剧集列表
+            # 如果使用者選擇全部下載 download_mode = 'all'
+            for ep in episode_list:  # 遍歷劇集列表
                 try:
                     db = read_db(ep)
-                    #           未下载的   或                设定要上传但是没上传的                         并且  还没在列队中
+                    #           未下載的   或                設定要上傳但是沒上傳的                         並且  還沒在列隊中
                     if (db['status'] == 0 or (db['remote_status'] == 0 and settings['upload_to_server'])) and ep not in queue.keys():
-                        queue[ep] = sn_dict[sn]  # 添加至下载列队
+                        queue[ep] = sn_dict[sn]  # 新增至下載列隊
                 except IndexError:
-                    # 如果数据库中尚不存在此条记录
+                    # 如果資料庫中尚不存在此條記錄
                     if anime.get_sn() == ep:
-                        new_anime = anime  # 如果是本身则不用重复创建实例
+                        new_anime = anime  # 如果是本身則不用重複建立例項
                     else:
                         new_anime = build_anime(ep)
                         if new_anime['failed']:
-                            err_print(ep, '更新狀態', '更新數據失敗, 跳過等待下次檢查', status=1)
+                            err_print(ep, '更新狀態', '更新數據失敗，跳過等待下次檢查', status=1)
                             continue
                         new_anime = new_anime['anime']
                     insert_db(new_anime)
-                    queue[ep] = sn_dict[sn]  # 添加至列队
+                    queue[ep] = sn_dict[sn]  # 新增至列隊
         else:
             if sn_dict[sn]['mode'] == 'largest-sn':
-                # 如果用户选择仅下载最新上传, download_mode = 'largest_sn', 则对 sn 进行排序
+                # 如果使用者選擇僅下載最新上傳, download_mode = 'largest_sn', 則對 sn 進行排序
                 episode_list.sort()
                 latest_sn = episode_list[-1]
-                # 否则用户选择仅下载最后剧集, download_mode = 'latest', 即下载网页上显示在最右的剧集
+                # 否則使用者選擇僅下載最後劇集, download_mode = 'latest', 即下載網頁上顯示在最右的劇集
             elif sn_dict[sn]['mode'] == 'single':
-                latest_sn = sn  # 适配命令行 sn-list 模式
+                latest_sn = sn  # 適配命令列 sn-list 模式
             else:
                 latest_sn = episode_list[-1]
             try:
                 db = read_db(latest_sn)
-                #           未下载的   或                设定要上传但是没上传的                         并且  还没在列队中
+                #           未下載的   或                設定要上傳但是沒上傳的                         並且  還沒在列隊中
                 if (db['status'] == 0 or (db['remote_status'] == 0 and settings['upload_to_server'])) and latest_sn not in queue.keys():
-                    queue[latest_sn] = sn_dict[sn]  # 添加至下载列队
+                    queue[latest_sn] = sn_dict[sn]  # 新增至下載列隊
             except IndexError:
-                # 如果数据库中尚不存在此条记录
+                # 如果資料庫中尚不存在此條記錄
                 if anime.get_sn() == latest_sn:
-                    new_anime = anime  # 如果是本身则不用重复创建实例
+                    new_anime = anime  # 如果是本身則不用重複建立例項
                 else:
                     new_anime = build_anime(latest_sn)
                     if new_anime['failed']:
-                        err_print(latest_sn, '更新狀態', '更新數據失敗, 跳過等待下次檢查', status=1)
+                        err_print(latest_sn, '更新狀態', '更新數據失敗，跳過等待下次檢查', status=1)
                         continue
                     new_anime = new_anime['anime']
                 insert_db(new_anime)
@@ -329,7 +329,7 @@ def check_tasks():
 
 
 def __download_only(sn, dl_resolution='', dl_save_dir='', realtime_show_file_size=False, classify=True):
-    # 仅下载,不操作数据库
+    # 僅下載，不操作資料庫
     thread_limiter.acquire()
     err_counter = 0
 
@@ -344,22 +344,22 @@ def __download_only(sn, dl_resolution='', dl_save_dir='', realtime_show_file_siz
         else:
             anime.download(settings['download_resolution'], dl_save_dir, realtime_show_file_size=realtime_show_file_size, classify=classify)
     except BaseException as e:
-        err_print(sn, '下載異常', '發生未知異常: ' + str(e), status=1)
-        err_print(sn, '下載異常', '異常詳情:\n'+traceback.format_exc(), status=1, display=False)
+        err_print(sn, '下載異常', '發生未知異常：' + str(e), status=1)
+        err_print(sn, '下載異常', '異常詳情：\n'+traceback.format_exc(), status=1, display=False)
         anime.video_size = 0
 
     while anime.video_size < 5:
         if err_counter >= 3:
-            err_print(sn, '終止任務', 'title=' + anime.get_title()+' 任務失敗達三次! 終止任務!', status=1)
+            err_print(sn, '終止任務', 'title=' + anime.get_title()+' 任務失敗達三次！終止任務！', status=1)
             thread_limiter.release()
             if int(sn) in Config.tasks_progress_rate.keys():
                 del Config.tasks_progress_rate[int(sn)]
             return
         else:
-            err_print(sn, '任務失敗', 'title=' + anime.get_title() + ' 10s后自動重啓,最多重試三次', status=1)
+            err_print(sn, '任務失敗', 'title=' + anime.get_title() + ' 10s 後自動重啟，最多重試三次', status=1)
             err_counter = err_counter + 1
             if int(sn) in Config.tasks_progress_rate.keys():
-                Config.tasks_progress_rate[int(sn)]['status'] = '失敗! 重啓中'
+                Config.tasks_progress_rate[int(sn)]['status'] = '失敗！重啟中'
             time.sleep(10)
             anime.renew()
 
@@ -369,8 +369,8 @@ def __download_only(sn, dl_resolution='', dl_save_dir='', realtime_show_file_siz
                 else:
                     anime.download(settings['download_resolution'], dl_save_dir, realtime_show_file_size=realtime_show_file_size, classify=classify)
             except BaseException as e:
-                err_print(sn, '下載異常', '發生未知異常: ' + str(e), status=1)
-                err_print(sn, '下載異常', '異常詳情:\n'+traceback.format_exc(), status=1, display=False)
+                err_print(sn, '下載異常', '發生未知異常：' + str(e), status=1)
+                err_print(sn, '下載異常', '異常詳情：\n'+traceback.format_exc(), status=1, display=False)
                 anime.video_size = 0
 
     thread_limiter.release()
@@ -386,7 +386,7 @@ def __get_info_only(sn):
     anime.set_resolution(resolution)
     anime.get_info()
     download_dir = settings['bangumi_dir']
-    if classify:  # 控制是否建立番剧文件夹
+    if classify:  # 控制是否建立番劇資料夾
         download_dir = os.path.join(download_dir, Config.legalize_filename(anime.get_bangumi_name()))
 
     if danmu:
@@ -415,9 +415,9 @@ def __cui(sn, cui_resolution, cui_download_mode, cui_thread_limit, ep_range,
 
     if cui_download_mode == 'single':
         if get_info:
-            print('當前模式: 查詢本集資訊\n')
+            print('當前模式：查詢本集資訊\n')
         else:
-            print('當前下載模式: 僅下載本集\n')
+            print('當前下載模式：僅下載本集\n')
 
         if get_info:
             __get_info_only(sn)
@@ -427,14 +427,14 @@ def __cui(sn, cui_resolution, cui_download_mode, cui_thread_limit, ep_range,
     elif cui_download_mode == 'latest' or cui_download_mode == 'largest-sn':
         if cui_download_mode == 'latest':
             if get_info:
-                print('當前模式: 查詢本番劇最後一集資訊\n')
+                print('當前模式：查詢本番劇最後一集資訊\n')
             else:
-                print('當前下載模式: 下載本番劇最後一集\n')
+                print('當前下載模式：下載本番劇最後一集\n')
         else:
             if get_info:
-                print('當前模式: 查詢本番劇最近上傳一集資訊\n')
+                print('當前模式：查詢本番劇最近上傳一集資訊\n')
             else:
-                print('當前下載模式: 下載本番劇最近上傳的一集\n')
+                print('當前下載模式：下載本番劇最近上傳的一集\n')
 
         anime = build_anime(sn)
         if anime['failed']:
@@ -453,9 +453,9 @@ def __cui(sn, cui_resolution, cui_download_mode, cui_thread_limit, ep_range,
 
     elif cui_download_mode == 'all':
         if get_info:
-            print('當前模式: 查詢本番劇所有劇集資訊\n')
+            print('當前模式：查詢本番劇所有劇集資訊\n')
         else:
-            print('當前下載模式: 下載本番劇所有劇集\n')
+            print('當前下載模式：下載本番劇所有劇集\n')
 
         anime = build_anime(sn)
         if anime['failed']:
@@ -464,7 +464,7 @@ def __cui(sn, cui_resolution, cui_download_mode, cui_thread_limit, ep_range,
 
         bangumi_list = list(anime.get_episode_list().values())
         bangumi_list.sort()
-        tasks_counter = 0  # 任务计数器
+        tasks_counter = 0  # 任務計數器
         for anime_sn in bangumi_list:
             if get_info:
                 task = threading.Thread(target=__get_info_only, args=(anime_sn,))
@@ -474,17 +474,17 @@ def __cui(sn, cui_resolution, cui_download_mode, cui_thread_limit, ep_range,
             thread_tasks.append(task)
             task.start()
             tasks_counter = tasks_counter + 1
-            print('添加任务列隊: sn=' + str(anime_sn))
+            print('添加任务列隊：sn=' + str(anime_sn))
         if get_info:
-            print('所有查詢任務已添加至列隊, 共 '+str(tasks_counter)+' 個任務\n')
+            print('所有查詢任務已添加至列隊，共 '+str(tasks_counter)+' 個任務\n')
         else:
-            print('所有下載任務已添加至列隊, 共 '+str(tasks_counter)+' 個任務, '+'執行緒數: ' + str(cui_thread_limit) + '\n')
+            print('所有下載任務已添加至列隊，共 '+str(tasks_counter)+' 個任務，'+'執行緒數：' + str(cui_thread_limit) + '\n')
 
     elif cui_download_mode == 'range':
         if get_info:
-            print('當前模式: 查詢本番劇指定劇集資訊\n')
+            print('當前模式：查詢本番劇指定劇集資訊\n')
         else:
-            print('當前下載模式: 下載本番劇指定劇集\n')
+            print('當前下載模式：下載本番劇指定劇集\n')
 
         anime = build_anime(sn)
         if anime['failed']:
@@ -492,8 +492,8 @@ def __cui(sn, cui_resolution, cui_download_mode, cui_thread_limit, ep_range,
         anime = anime['anime']
 
         episode_dict = anime.get_episode_list()
-        bangumi_ep_list = list(episode_dict.keys())  # 本番剧集列表
-        tasks_counter = 0  # 任务计数器
+        bangumi_ep_list = list(episode_dict.keys())  # 本番劇集列表
+        tasks_counter = 0  # 任務計數器
         for ep in ep_range:
             if ep in bangumi_ep_list:
                 if get_info:
@@ -505,32 +505,32 @@ def __cui(sn, cui_resolution, cui_download_mode, cui_thread_limit, ep_range,
                 a.start()
                 tasks_counter = tasks_counter + 1
                 if get_info:
-                    print('添加查詢列隊: sn=' + str(episode_dict[ep]) + ' 《' + anime.get_bangumi_name() + '》 第 ' + ep + ' 集')
+                    print('添加查詢列隊：sn=' + str(episode_dict[ep]) + ' 《' + anime.get_bangumi_name() + '》 第 ' + ep + ' 集')
                 else:
-                    print('添加任务列隊: sn='+str(episode_dict[ep])+' 《'+anime.get_bangumi_name()+'》 第 '+ep+' 集')
+                    print('添加任务列隊：sn='+str(episode_dict[ep])+' 《'+anime.get_bangumi_name()+'》 第 '+ep+' 集')
             else:
-                err_print(0, '《'+anime.get_bangumi_name()+'》 第 '+ep+' 集不存在!', status=1, no_sn=True)
-        print('所有任務已添加至列隊, 共 '+str(tasks_counter)+' 個任務, '+'執行緒數: ' + str(cui_thread_limit) + '\n')
+                err_print(0, '《'+anime.get_bangumi_name()+'》 第 '+ep+' 集不存在！', status=1, no_sn=True)
+        print('所有任務已添加至列隊, 共 '+str(tasks_counter)+' 個任務, '+'執行緒數：' + str(cui_thread_limit) + '\n')
 
     elif cui_download_mode == 'sn-range':
         if get_info:
-            print('當前模式: 查詢本番劇指定sn範圍資訊\n')
+            print('當前模式：查詢本番劇指定 sn 範圍資訊\n')
         else:
-            print('當前下載模式: 下載本番劇指定sn範圍劇集\n')
+            print('當前下載模式：下載本番劇指定 sn 範圍劇集\n')
 
         anime = build_anime(sn)
         if anime['failed']:
             sys.exit(1)
         anime = anime['anime']
 
-        # 剧集列表 key value 互换, {'sn', '剧集名'}
+        # 劇集列表 key value 互換, {'sn', '劇集名'}
         episode_dict = {value:key for key,value in anime.get_episode_list().items()}
-        ep_sn_list = list(episode_dict.keys())  # 本番剧集sn列表
-        tasks_counter = 0  # 任务计数器
+        ep_sn_list = list(episode_dict.keys())  # 本番劇集sn列表
+        tasks_counter = 0  # 任務計數器
         ep_range = list(map(lambda x: int(x), ep_range))
         for sn in ep_sn_list:
             if sn in ep_range:
-                # 如果该 sn 在用户指定的 sn 范围里
+                # 如果該 sn 在使用者指定的 sn 範圍裡
                 if get_info:
                     a = threading.Thread(target=__get_info_only, args=(sn,))
                 else:
@@ -540,34 +540,34 @@ def __cui(sn, cui_resolution, cui_download_mode, cui_thread_limit, ep_range,
                 a.start()
                 tasks_counter = tasks_counter + 1
                 if get_info:
-                    print('添加查詢列隊: sn=' + str(sn) + ' 《' + anime.get_bangumi_name() + '》 第 ' + episode_dict[sn] + ' 集')
+                    print('添加查詢列隊：sn=' + str(sn) + ' 《' + anime.get_bangumi_name() + '》 第 ' + episode_dict[sn] + ' 集')
                 else:
-                    print('添加任务列隊: sn='+str(sn)+' 《'+anime.get_bangumi_name()+'》 第 ' + episode_dict[sn] + ' 集')
-        print('所有任務已添加至列隊, 共 ' + str(tasks_counter) + ' 個任務, ' + '執行緒數: ' + str(cui_thread_limit) + '\n')
+                    print('添加任务列隊：sn='+str(sn)+' 《'+anime.get_bangumi_name()+'》 第 ' + episode_dict[sn] + ' 集')
+        print('所有任務已添加至列隊，共 ' + str(tasks_counter) + ' 個任務，' + '執行緒數：' + str(cui_thread_limit) + '\n')
 
     elif cui_download_mode == 'multi':
         if get_info:
-            print('當前模式: 查詢指定sn資訊\n')
+            print('當前模式：查詢指定 sn 資訊\n')
         else:
-            print('當前下載模式: 下載指定sn劇集\n')
+            print('當前下載模式：下載指定 sn 劇集\n')
 
         tasks_counter = 0
         for sn in ep_range:
             if get_info:
                 a = threading.Thread(target=__get_info_only, args=(sn,))
             else:
-                a = threading.Thread(target=__download_only,args=(sn, cui_resolution, cui_save_dir, realtime_show_file_size))
+                a = threading.Thread(target=__download_only, args=(sn, cui_resolution, cui_save_dir, realtime_show_file_size))
             a.setDaemon(True)
             thread_tasks.append(a)
             a.start()
             tasks_counter = tasks_counter + 1
 
-        print('所有任務已添加至列隊, 共 ' + str(tasks_counter) + ' 個任務, ' + '執行緒數: ' + str(cui_thread_limit) + '\n')
+        print('所有任務已添加至列隊，共 ' + str(tasks_counter) + ' 個任務，' + '執行緒數：' + str(cui_thread_limit) + '\n')
 
     elif cui_download_mode in ('list', 'sn-list'):
         if get_info:
-            # 如果為list模式也仅查询名单中的sn信息, 可用于检查sn是否输入正确
-            print('當前模式: 查詢sn_list.txt中指定sn的資訊\n')
+            # 如果為list模式也僅查詢名單中的sn資訊，可用於檢查sn是否輸入正確
+            print('當前模式：查詢 sn_list.txt 中指定 sn 的資訊\n')
             ep_range = Config.read_sn_list().keys()
             for sn in ep_range:
                 anime = build_anime(sn)
@@ -577,39 +577,39 @@ def __cui(sn, cui_resolution, cui_download_mode, cui_thread_limit, ep_range,
                 anime.get_info()
         else:
             if cui_download_mode == 'sn-list':
-                print('當前下載模式: 下載sn_list.txt中指定的sn劇集\n')
+                print('當前下載模式：下載 sn_list.txt 中指定的 sn 劇集\n')
                 for i in sn_dict:
                     sn_dict[i]['mode'] = 'single'
             else:
-                print('當前下載模式: 單次下載sn_list.txt中的番劇\n')
+                print('當前下載模式：單次下載 sn_list.txt 中的番劇\n')
 
-            check_tasks()  # 检查更新，生成任务列队
-            for sn in queue.keys():  # 遍历任务列队
+            check_tasks()  # 檢查更新，生成任務列隊
+            for sn in queue.keys():  # 遍歷任務列隊
                 processing_queue.append(sn)
                 task = threading.Thread(target=worker, args=(sn, queue[sn], realtime_show_file_size))
                 task.setDaemon(True)
                 thread_tasks.append(task)
                 task.start()
-                err_print(sn, '加入任务列隊')
+                err_print(sn, '加入任務列隊')
             msg = '共 ' + str(len(queue)) + ' 個任務'
             err_print(0, '任務資訊', msg, no_sn=True)
             print()
 
     __kill_thread_when_ctrl_c()
-    kill_gost()  # 结束 gost
+    kill_gost()  # 結束 gost
 
-    # 结束后执行用户自定义命令
+    # 結束後執行使用者自定義命令
     if user_cmd:
         print()
         os.popen(settings['user_command'])
-        err_print(0, '任務完成', '已執行用戶命令', no_sn=True, status=2)
+        err_print(0, '任務完成', '已執行使用者自定義命令', no_sn=True, status=2)
 
     sys.exit(0)
 
 
 def __kill_thread_when_ctrl_c():
-    # 等待所有任务完成
-    for t in thread_tasks:  # 当用户 Ctrl+C 可以 kill 线程
+    # 等待所有任務完成
+    for t in thread_tasks:  # 當用戶 Ctrl+C 可以 kill 執行緒
         while True:
             if t.is_alive():
                 time.sleep(1)
@@ -619,12 +619,12 @@ def __kill_thread_when_ctrl_c():
 
 def kill_gost():
     if gost_subprocess is not None:
-        gost_subprocess.kill()  # 结束 gost
+        gost_subprocess.kill()  # 結束 gost
 
 
 def user_exit(signum, frame):
-    err_print(0, '你終止了程序!', '\n', status=1, no_sn=True, prefix='\n\n')
-    kill_gost()  # 结束 gost
+    err_print(0, '你終止了程式！', '\n', status=1, no_sn=True, prefix='\n\n')
+    kill_gost()  # 結束 gost
     sys.exit(255)
 
 
@@ -632,49 +632,49 @@ def check_new_version():
     # 检查GitHub上是否有新版
     remote_version = Config.read_latest_version_on_github()
     if float(settings['aniGamerPlus_version'][1:]) < float(remote_version['tag_name'][1:]):
-        msg = '發現GitHub上有新版本: '+remote_version['tag_name']+'\n更新内容:\n'+remote_version['body']+'\n'
+        msg = '發現 GitHub 上有新版本: '+remote_version['tag_name']+'\n更新内容：\n'+remote_version['body']+'\n'
         err_print(0, msg, status=1, no_sn=True)
 
 
 def __init_proxy():
     if settings['use_gost']:
-        print('使用代理連接動畫瘋, 使用擴展的代理協議')
-        # 需要使用 gost 的情况
-        # 寻找 gost
+        print('使用代理連線動畫瘋，使用擴充套件的代理協議')
+        # 需要使用 gost 的情況
+        # 尋找 gost
         check_gost = subprocess.Popen('gost -h', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if check_gost.stderr.readlines():  # 查找 gost 是否已放入系统 path
+        if check_gost.stderr.readlines():  # 查詢 gost 是否已放入系統 path
             gost_path = 'gost'
         else:
-            # print('没有在系统PATH中发现gost，尝试在所在目录寻找')
+            # print('沒有在系統PATH中發現gost，嘗試在所在目錄尋找')
             if 'Windows' in platform.system():
                 gost_path = os.path.join(working_dir, 'gost.exe')
             else:
                 gost_path = os.path.join(working_dir, 'gost')
             if not os.path.exists(gost_path):
                 err_print(0, '當前代理使用擴展協議, 需要使用gost, 但是gost未找到', status=1, no_sn=True)
-                raise FileNotFoundError  # 如果本地目录下也没有找到 gost 则丢出异常
-        # 构造 gost 命令
-        gost_cmd = [gost_path, '-L=:'+str(gost_port), '-F=' + settings['proxy']]  # 本地监听端口 34173
+                raise FileNotFoundError  # 如果本地目錄下也沒有找到 gost 則丟出異常
+        # 建構 gost 指令
+        gost_cmd = [gost_path, '-L=:'+str(gost_port), '-F=' + settings['proxy']]  # 本地監聽埠 34173
 
         def run_gost():
-            # gost 线程
+            # gost 執行緒
             global gost_subprocess
             gost_subprocess = subprocess.Popen(gost_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             gost_subprocess.communicate()
 
         run_gost_threader = threading.Thread(target=run_gost)
         run_gost_threader.setDaemon(True)
-        run_gost_threader.start()  # 启动 gost
-        time.sleep(3)  # 给时间让 gost 启动
+        run_gost_threader.start()  # 啟動 gost
+        time.sleep(3)  # 給時間讓 gost 啟動
 
     else:
-        print('使用代理連接動畫瘋, 使用http/https/socks5協議')
+        print('使用代理連接動畫瘋，使用http/https/socks5 協議')
 
 
 def run_dashboard():
-    # 检测端口是否占用
+    # 檢測埠是否佔用
     if not port_is_available(settings['dashboard']['port']):
-        err_print(0, 'Web控制面板啓動失敗', 'Port已被占用! 請到配置文件更換', status=1, no_sn=True)
+        err_print(0, 'Web控制面板啟動失敗', 'Port已被佔用！請到設定檔案更換', status=1, no_sn=True)
         return
 
     from Dashboard.Server import run as dashboard
@@ -687,13 +687,13 @@ def run_dashboard():
         dashboard_address = 'http://'
     if settings['dashboard']['host'] == '0.0.0.0':
         host = Config.get_local_ip()
-        dashboard_address = '【開放外部訪問】訪問地址: ' + dashboard_address
+        dashboard_address = '【開放外部存取】存取地址: ' + dashboard_address
     else:
         host = settings['dashboard']['host']
-        dashboard_address = '訪問地址: ' + dashboard_address
+        dashboard_address = '存取地址: ' + dashboard_address
 
     dashboard_address = dashboard_address + host + ':' + str(settings['dashboard']['port'])
-    err_print(0, 'Web控制面板已啓動', dashboard_address, no_sn=True, status=2)
+    err_print(0, 'Web 控制面板已啟動', dashboard_address, no_sn=True, status=2)
 
 
 signal.signal(signal.SIGINT, user_exit)
@@ -701,25 +701,25 @@ signal.signal(signal.SIGTERM, user_exit)
 settings = Config.read_settings()
 working_dir = settings['working_dir']
 db_path = os.path.join(working_dir, 'aniGamer.db')
-queue = {}  # 储存 sn 相关信息, {'tag': TAG, 'rename': RENAME}, rename,
+queue = {}  # 儲存 sn 相關資訊, {'tag': TAG, 'rename': RENAME}, rename,
 processing_queue = []
-thread_limiter = threading.Semaphore(settings['multi-thread'])  # 下载并发限制器
-upload_limiter = threading.Semaphore(settings['multi_upload'])  # 并发上传限制器
+thread_limiter = threading.Semaphore(settings['multi-thread'])  # 下載併發限制器
+upload_limiter = threading.Semaphore(settings['multi_upload'])  # 併發上傳限制器
 db_locker = threading.Semaphore(1)
 thread_tasks = []
-gost_subprocess = None  # 存放 gost 的 subprocess.Popen 对象, 用于结束时 kill gost
-gost_port = gost_port()  # gost 端口
+gost_subprocess = None  # 存放 gost 的 subprocess.Popen 物件, 用於結束時 kill gost
+gost_port = gost_port()  # gost 埠
 sn_dict = Config.read_sn_list()
 danmu = settings['danmu']
 
 if __name__ == '__main__':
     if settings['check_latest_version']:
-        check_new_version()  # 检查新版
-    version_msg = '當前aniGamerPlus版本: ' + settings['aniGamerPlus_version']
-    print(version_msg)
+        check_new_version()  # 檢查新版
+        version_msg = '當前aniGamerPlus版本: ' + settings['aniGamerPlus_version']
+        print(version_msg)
 
-    # 初始化 sqlite3 数据库
-    conn = sqlite3.connect(db_path)
+        # 初始化 sqlite3 資料庫
+        conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
     cursor.execute('CREATE TABLE IF NOT EXISTS anime ('
                    'sn INTEGER PRIMARY KEY NOT NULL,'
@@ -735,34 +735,34 @@ if __name__ == '__main__':
     conn.commit()
     conn.close()
 
-    if len(sys.argv) > 1:  # 支持命令行使用
+    if len(sys.argv) > 1:  # 支援命令列使用
         parser = argparse.ArgumentParser()
-        parser.add_argument('--sn', '-s', type=int, help='視頻sn碼(數字)')
-        parser.add_argument('--resolution', '-r', type=int, help='指定下載清晰度(數字)', choices=[360, 480, 540, 576, 720, 1080])
+        parser.add_argument('--sn', '-s', type=int, help='影片 sn 碼（數字）')
+        parser.add_argument('--resolution', '-r', type=int, help='指定下載解析度（數字）', choices=[360, 480, 540, 576, 720, 1080])
         parser.add_argument('--download_mode', '-m', type=str, help='下載模式', default='single',
                             choices=['single', 'latest', 'largest-sn', 'multi', 'all', 'range', 'list', 'sn-list', 'sn-range'])
-        parser.add_argument('--thread_limit', '-t', type=int, help='最高并發下載數(數字)')
+        parser.add_argument('--thread_limit', '-t', type=int, help='最高併發下載數（數字）')
         parser.add_argument('--current_path', '-c', action='store_true', help='下載到當前工作目錄')
         parser.add_argument('--episodes', '-e', type=str, help='僅下載指定劇集')
         parser.add_argument('--no_classify', '-n', action='store_true', help='不建立番劇資料夾')
-        parser.add_argument('--user_command', '-u', action='store_true', help='所有下載完成后執行用戶命令')
+        parser.add_argument('--user_command', '-u', action='store_true', help='所有下載完成後執行使用者命令')
         parser.add_argument('--information_only', '-i', action='store_true', help='僅查詢資訊，可搭配 -d 更新彈幕')
         parser.add_argument('--danmu', '-d', action='store_true', help='以 .ass 下載彈幕(beta)')
         arg = parser.parse_args()
 
         if (arg.download_mode not in ('list', 'multi', 'sn-list')) and arg.sn is None:
-            err_print(0, '參數錯誤', '非 list/multi 模式需要提供 sn ', no_sn=True, status=1)
+            err_print(0, '引數錯誤', '非 list/multi 模式需要提供 sn ', no_sn=True, status=1)
             sys.exit(1)
 
         save_dir = ''
         download_mode = arg.download_mode
         if arg.current_path:
             save_dir = os.getcwd()
-            info = '使用命令行模式, 指定下載到當前目錄: '
+            info = '使用命令列模式，指定下載到當前目錄：'
             print(info + '\n    ' + save_dir)
             err_print(0, info + save_dir, no_sn=True, display=False)
         else:
-            info = '使用命令行模式, 文件將保存在配置文件中指定的目錄下: '
+            info = '使用命令列模式，檔案將儲存在設定檔案中指定的目錄下：'
             print(info + '\n    ' + settings['bangumi_dir'])
             err_print(0, info + settings['bangumi_dir'], no_sn=True, display=False)
 
@@ -772,13 +772,13 @@ if __name__ == '__main__':
             print('將不會建立番劇資料夾')
 
         if not arg.episodes and arg.download_mode == 'range':
-            err_print(0, 'ERROR: 當前為指定範圍模式, 但範圍未指定!', status=1, no_sn=True)
+            err_print(0, 'ERROR：當前為指定範圍模式，但範圍未指定！', status=1, no_sn=True)
             sys.exit(1)
 
         download_episodes = []
         if arg.episodes or arg.download_mode == 'sn-list':
             if arg.download_mode == 'multi':
-                # 如果此时为 multi 模式, 则 download_episodes 装的是 sn 码
+                # 如果此時為 multi 模式，則 download_episodes 裝的是 sn 碼
                 for i in arg.episodes.split(','):
                     if re.match(r'^\d+$', i):
                         download_episodes.append(int(i))
@@ -786,7 +786,7 @@ if __name__ == '__main__':
                     download_episodes.append(arg.sn)
 
             elif arg.download_mode == 'sn-list':
-                # 如果此时为 sn-list 模式, 则 download_episodes 装的是 sn_list.txt 里的 sn 码
+                # 如果此時為 sn-list 模式，則 download_episodes 裝的是 sn_list.txt 裡的 sn 碼
                 download_episodes = list(Config.read_sn_list().keys())
 
             else:
@@ -794,40 +794,40 @@ if __name__ == '__main__':
                     if re.match(r'^\d+-\d+$', i):
                         episodes_range_start = int(i.split('-')[0])
                         episodes_range_end = int(i.split('-')[1])
-                        if episodes_range_start > episodes_range_end:  # 如果有zz从大到小写
+                        if episodes_range_start > episodes_range_end:  # 如果有 zz 從大到小寫
                             episodes_range_start, episodes_range_end = episodes_range_end, episodes_range_start
                         download_episodes.extend(list(range(episodes_range_start, episodes_range_end + 1)))
                     if re.match(r'^\d+$', i):
                         download_episodes.append(int(i))
                 if arg.download_mode != 'sn-range':
-                    download_mode = 'range'  # 如果带 -e 参数没有指定 multi 模式, 则默认为 range 模式
+                    download_mode = 'range'  # 如果帶 -e 引數沒有指定 multi 模式, 則預設為 range 模式
 
-            download_episodes = list(set(download_episodes))  # 去重复
-            download_episodes.sort()  # 排序, 任务将会按集数顺序下载
-            # 转为 str, 方便作为 Anime.get_episode_list() 的 key
+            download_episodes = list(set(download_episodes))  # 去重複
+            download_episodes.sort()  # 排序, 任務將會按集數順序下載
+            # 轉為 str, 方便作為 Anime.get_episode_list() 的 key
             download_episodes = list(map(lambda x: str(x), download_episodes))
 
         if not arg.resolution:
             resolution = settings['download_resolution']
-            print('未设定下载解析度, 将使用配置文件指定的清晰度: ' + resolution + 'P')
+            print('未設定下載解析度，將使用設定檔案指定的解析度：' + resolution + 'P')
         else:
             if arg.download_mode in ('sn-list', 'list'):
-                err_print(0,'無效參數:', 'list 及 sn-list 模式無法通過命令行指定清晰度', 1, no_sn=True, display_time=False)
+                err_print(0,'無效參數:', 'list 及 sn-list 模式無法透過命令列指定解析度', 1, no_sn=True, display_time=False)
                 resolution = settings['download_resolution']
-                print('将使用配置文件指定的清晰度: ' + resolution + 'P')
+                print('將使用設定檔案指定的解析度：' + resolution + 'P')
             else:
                 resolution = str(arg.resolution)
-                print('指定下载解析度: ' + resolution + 'P')
+                print('指定下載解析度: ' + resolution + 'P')
 
         if arg.information_only:
-            # 为避免排版混乱, 仅显示信息时强制为单线程
+            # 為避免排版混亂，僅顯示資訊時強制為單執行緒
             thread_limit = 1
             thread_limiter = threading.Semaphore(thread_limit)
         else:
             if arg.thread_limit:
-                # 用戶設定并發數
+                # 使用者設定並發數
                 if arg.thread_limit > Config.get_max_multi_thread():
-                    # 是否超过最大允许线程数
+                    # 是否超過最大允許執行緒數
                     thread_limit = Config.get_max_multi_thread()
                 else:
                     thread_limit = arg.thread_limit
@@ -849,8 +849,8 @@ if __name__ == '__main__':
         __cui(arg.sn, resolution, download_mode, thread_limit, download_episodes, save_dir, classify,
               get_info=arg.information_only, user_cmd=user_command, cui_danmu=danmu)
 
-    err_print(0, '自動模式啓動aniGamerPlus '+version_msg, no_sn=True, display=False)
-    err_print(0, '工作目錄: ' + working_dir, no_sn=True, display=False)
+    err_print(0, '自動模式啟動 aniGamerPlus ' + version_msg, no_sn=True, display=False)
+    err_print(0, '工作目錄：' + working_dir, no_sn=True, display=False)
 
     if settings['use_proxy']:
         __init_proxy()
@@ -861,24 +861,24 @@ if __name__ == '__main__':
     while True:
         print()
         err_print(0, '開始更新', no_sn=True)
-        Config.test_cookie()  # 测试cookie
+        Config.test_cookie()  # 測試 cookie
         if settings['read_sn_list_when_checking_update']:
             sn_dict = Config.read_sn_list()
         if settings['read_config_when_checking_update']:
             settings = Config.read_settings()
-        danmu = settings['danmu'] # 避免手動加入工作時，global 覆寫掉 config 的 danmu 設定
-        check_tasks()  # 检查更新，生成任务列队
-        new_tasks_counter = 0  # 新增任务计数器
+        danmu = settings['danmu']  # 避免手動加入工作時，global 覆寫掉 config 的 danmu 設定
+        check_tasks()  # 檢查更新，生成任務列隊
+        new_tasks_counter = 0  # 新增任務計數器
         if queue:
             for task_sn in queue.keys():
-                if task_sn not in processing_queue:  # 如果该任务没有在进行中，则启动
+                if task_sn not in processing_queue:  # 如果該任務沒有在進行中，則啟動
                     task = threading.Thread(target=worker, args=(task_sn, queue[task_sn]))
                     task.setDaemon(True)
                     task.start()
                     processing_queue.append(task_sn)
                     new_tasks_counter = new_tasks_counter + 1
-                    err_print(task_sn, '加入任务列隊')
-        info = '本次更新添加了 '+str(new_tasks_counter)+' 個新任務, 目前列隊中共有 ' + str(len(processing_queue)) + ' 個任務'
+                    err_print(task_sn, '加入任務列隊')
+                    info = '本次新增了 ' + str(new_tasks_counter) + ' 個新任務, 目前列隊中共有 ' + str(len(processing_queue)) + ' 個任務'
         err_print(0, '更新資訊', info, no_sn=True)
         err_print(0, '更新终了', no_sn=True)
         print()

--- a/aniGamerPlus.py
+++ b/aniGamerPlus.py
@@ -524,7 +524,7 @@ def __cui(sn, cui_resolution, cui_download_mode, cui_thread_limit, ep_range,
         anime = anime['anime']
 
         # 劇集列表 key value 互換, {'sn', '劇集名'}
-        episode_dict = {value:key for key,value in anime.get_episode_list().items()}
+        episode_dict = {value: key for key, value in anime.get_episode_list().items()}
         ep_sn_list = list(episode_dict.keys())  # 本番劇集sn列表
         tasks_counter = 0  # 任務計數器
         ep_range = list(map(lambda x: int(x), ep_range))
@@ -715,11 +715,11 @@ danmu = settings['danmu']
 if __name__ == '__main__':
     if settings['check_latest_version']:
         check_new_version()  # 檢查新版
-        version_msg = '當前aniGamerPlus版本: ' + settings['aniGamerPlus_version']
-        print(version_msg)
+    version_msg = '當前aniGamerPlus版本: ' + settings['aniGamerPlus_version']
+    print(version_msg)
 
-        # 初始化 sqlite3 資料庫
-        conn = sqlite3.connect(db_path)
+    # 初始化 sqlite3 資料庫
+    conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
     cursor.execute('CREATE TABLE IF NOT EXISTS anime ('
                    'sn INTEGER PRIMARY KEY NOT NULL,'
@@ -812,7 +812,7 @@ if __name__ == '__main__':
             print('未設定下載解析度，將使用設定檔案指定的解析度：' + resolution + 'P')
         else:
             if arg.download_mode in ('sn-list', 'list'):
-                err_print(0,'無效參數:', 'list 及 sn-list 模式無法透過命令列指定解析度', 1, no_sn=True, display_time=False)
+                err_print(0, '無效參數:', 'list 及 sn-list 模式無法透過命令列指定解析度', 1, no_sn=True, display_time=False)
                 resolution = settings['download_resolution']
                 print('將使用設定檔案指定的解析度：' + resolution + 'P')
             else:
@@ -878,9 +878,9 @@ if __name__ == '__main__':
                     processing_queue.append(task_sn)
                     new_tasks_counter = new_tasks_counter + 1
                     err_print(task_sn, '加入任務列隊')
-                    info = '本次新增了 ' + str(new_tasks_counter) + ' 個新任務, 目前列隊中共有 ' + str(len(processing_queue)) + ' 個任務'
+        info = '本次新增了 ' + str(new_tasks_counter) + ' 個新任務，目前列隊中共有 ' + str(len(processing_queue)) + ' 個任務'
         err_print(0, '更新資訊', info, no_sn=True)
         err_print(0, '更新终了', no_sn=True)
         print()
         for i in range(settings['check_frequency'] * 60):
-            time.sleep(1)  # cool down, 這麽寫是爲了可以 Ctrl+C 馬上退出
+            time.sleep(1)  # cool down，這麽寫是爲了可以 Ctrl+C 馬上退出


### PR DESCRIPTION
# 理由
在此專案內有許多貢獻者一同維護著，但大家的寫程式的習慣、用語、用詞不一，造成後人想要提供維護的意願、難度門檻提高。  

# 統一格式
最後我將此專案內的檔案按照 [中文文案排版指北](https://github.com/sparanoid/chinese-copywriting-guidelines)指引，將用語、格式逐一更改。
## 例如：
| 啓 | ➡️ | 啟 |
|----|--|----|
| 志 | ➡️  | 誌 |
| , | ➡️  | ， |
| 并 | ➡️ | 併 |

## 原先：  
> 新增开关: 每次检查更新时读取config.json  

## 更改後：  
> 新增開關：每次檢查更新時讀取 config.json  

如有其他建議、想法希望能夠進一步討論。