### PR TITLE
修正呼叫Danmu時缺少cookie參數的問題

### DIFF
--- a/Anime.py
+++ b/Anime.py
@@ -884,7 +884,7 @@ class Anime:
         # 下載彈幕
         if self._danmu:
             full_filename = os.path.join(self._bangumi_dir, self.__get_filename(resolution)).replace('.' + self._settings['video_filename_extension'], '.ass')
-            d = Danmu(self._sn, full_filename)
+            d = Danmu(self._sn, full_filename, Config.read_cookie())
             d.download(self._settings['danmu_ban_words'])
 
         # 推送 CQ 通知


### PR DESCRIPTION
修正以下問題

```
2022-03-29 14:00:19 下載異常: sn=28227	發生未知異常: __init__() missing 1 required positional argument: 'cookies'
2022-03-29 14:00:19 下載異常: sn=28227	異常詳情:
Traceback (most recent call last):
  File "aniGamerPlus.py", line 343, in __download_only
  File "Anime.py", line 887, in download
TypeError: __init__() missing 1 required positional argument: 'cookies'
```