### PR TITLE
新增telegram bot指定发送chat id

### DIFF
--- a/Anime.py
+++ b/Anime.py
@@ -912,7 +912,7 @@ class Anime:
                 vApiTokenTelegram = self._settings['telebot_token']
                 try:
                     if self._settings['telebot_use_chat_id']: #手动指定发送目标
-                        chat_id = self._settings['telebot__chat_id']
+                        chat_id = self._settings['telebot_chat_id']
                     else:
                         apiMethod = "getUpdates"
                         api_url = "https://api.telegram.org/bot" + vApiTokenTelegram + "/" + apiMethod # Telegram bot api url

--- a/Anime.py
+++ b/Anime.py
@@ -910,11 +910,14 @@ class Anime:
             try:
                 msg = '【aniGamerPlus消息】\n《' + self._video_filename + '》下载完成, 本集 ' + str(self.video_size) + ' MB'
                 vApiTokenTelegram = self._settings['telebot_token']
-                apiMethod = "getUpdates"
-                api_url = "https://api.telegram.org/bot" + vApiTokenTelegram + "/" + apiMethod # Telegram bot api url
                 try:
-                    response = self.__request(api_url).json()
-                    chat_id = response["result"][0]["message"]["chat"]["id"] # Get chat id
+                    if self._settings['telebot_use_chat_id']: #手动指定发送目标
+                        chat_id = self._settings['telebot__chat_id']
+                    else:
+                        apiMethod = "getUpdates"
+                        api_url = "https://api.telegram.org/bot" + vApiTokenTelegram + "/" + apiMethod # Telegram bot api url
+                        response = self.__request(api_url).json()
+                        chat_id = response["result"][0]["message"]["chat"]["id"] # Get chat id
                     try:
                         api_method = "sendMessage"
                         req = "https://api.telegram.org/bot" \

--- a/Anime.py
+++ b/Anime.py
@@ -911,7 +911,7 @@ class Anime:
                 msg = '【aniGamerPlus消息】\n《' + self._video_filename + '》下载完成, 本集 ' + str(self.video_size) + ' MB'
                 vApiTokenTelegram = self._settings['telebot_token']
                 try:
-                    if self._settings['telebot_use_chat_id']: #手动指定发送目标
+                    if self._settings['telebot_use_chat_id'] and self._settings['telebot_chat_id']:  #手动指定发送目标
                         chat_id = self._settings['telebot_chat_id']
                     else:
                         apiMethod = "getUpdates"

--- a/Config.py
+++ b/Config.py
@@ -126,6 +126,8 @@ def __init_settings():
                 },
                 'telebot_notify': False,
                 'telebot_token': "",
+                'telebot_use_chat_id': False
+                'telebot_chat_id': "",
                 'discord_notify': False,
                 'discord_token': '',
                 'plex_refresh': False,
@@ -257,6 +259,8 @@ def __update_settings(old_settings):  # 升级配置文件
         # 新增推送通知到TG的功能
         new_settings['telebot_notify'] = False
         new_settings['telebot_token'] = ""
+        new_settings['telebot_use_chat_id'] = False
+        new_settings['telebot_chat_id'] = ""
 
     if 'discord_notify' not in new_settings.keys():
         # 新增推送通知到TG的功能

--- a/Config.py
+++ b/Config.py
@@ -126,7 +126,7 @@ def __init_settings():
                 },
                 'telebot_notify': False,
                 'telebot_token': "",
-                'telebot_use_chat_id': False
+                'telebot_use_chat_id': False,
                 'telebot_chat_id': "",
                 'discord_notify': False,
                 'discord_token': '',


### PR DESCRIPTION
当设置 'telebot_use_chat_id'为 true 时，bot信息将会发送至指定chat id目标。
[chat id获取方法 ](https://github.com/GabrielRF/telegram-id#web-channel-id)
[private channel id获取方法](https://community.jamaicans.dev/t/get-the-telegram-channel-id/427)