### PR TITLE
fix gvent Docker build fail cause by not support python version 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ termcolor==1.1.0
 flask==1.1.4
 requests==2.28.1
 chardet==3.0.4
-gevent==21.12.0
+gevent==22.08.0
 flask_basicauth==0.2.0
 flask_sockets==0.2.1
 beautifulsoup4==4.11.1


### PR DESCRIPTION
Fixes #222 .

It seems docker build fail is because 

gevent==21.12.0 not support python 3.11 build, but current Dockerfile will pull down Python 3.11

https://github.com/miyouzi/aniGamerPlus/blob/a2387121a47a2d83e268875c829a194606564f9a/Dockerfile#L1

https://hub.docker.com/layers/library/python/slim/images/sha256-b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a?context=explore

I **update gevent version instead of Dockerfile version**, it is success.
And if changing **Docker file python into Python 3.8-slim, keep gevent version** is also work.

I'll first open this PR about update gevent version, and if @miyouzi and @TonyPepeBear you think is more appropriate to keep Dockerfile python version in 3.8, then I will open another PR for you,

Thank you