### PR TITLE
修復 巴哈防爬抓檔

### DIFF
--- a/Anime.py
+++ b/Anime.py
@@ -7,7 +7,7 @@ import ftplib
 import shutil
 import traceback
 import Config
-import pyhttpx
+from curl_cffi import requests as curl_requests
 from Danmu import Danmu
 from bs4 import BeautifulSoup
 import re, time, os, platform, subprocess, requests, random, sys
@@ -31,11 +31,11 @@ class Anime:
         self._temp_dir = self._settings['temp_dir']
         self._gost_port = str(gost_port)
 
-        self._session = requests.session()
         if 'firefox' in self._settings['ua'].lower():
-            self._pyhttpx_session = pyhttpx.HttpSession(browser_type='firefox')
+            impersonate = 'firefox'
         else:
-            self._pyhttpx_session = pyhttpx.HttpSession(browser_type='chrome')
+            impersonate = 'chrome124'
+        self._session = curl_requests.Session(impersonate=impersonate)
         self._title = ''
         self._sn = sn
         self._bangumi_name = ''
@@ -134,7 +134,7 @@ class Anime:
             self._src = self.__request_json(f'https://api.gamer.com.tw/mobile_app/anime/v4/video.php?sn={self._sn}', no_cookies=True)
         else:
             req = f'https://ani.gamer.com.tw/animeVideo.php?sn={self._sn}'
-            f = self.__request(req, no_cookies=True, use_pyhttpx=True)
+            f = self.__request(req, no_cookies=True)
             self._src = BeautifulSoup(f.content, "lxml")
 
     def __get_title(self):
@@ -277,15 +277,10 @@ class Anime:
             cookies = {}
         while True:
             try:
-                if use_pyhttpx:
-                    # https://github.com/miyouzi/aniGamerPlus/issues/249 pyhttpx 作者 在改動
-                    # https://github.com/zero3301/pyhttpx/commit/4735190df741f4c00287ec948f0734fd2c21bfee
-                    # 把 proxy 驗證放到了 proxies URL 裏面
-                    f = self._pyhttpx_session.get(req, headers=current_header, cookies=cookies, timeout=10,
-                                                  proxies=self._proxies)
-                else:
-                    f = self._session.get(req, headers=current_header, cookies=cookies, timeout=10)
-            except requests.exceptions.RequestException as e:
+                proxies = self._proxies if self._proxies else None
+                f = self._session.get(req, headers=current_header, cookies=cookies, timeout=10,
+                                      proxies=proxies)
+            except (requests.exceptions.RequestException, curl_requests.RequestsError) as e:
                 if error_cnt >= max_retry >= 0:
                     raise TryTooManyTimeError('任務狀態: sn=' + str(self._sn) + ' 请求失败次数过多！请求链接：\n%s' % req)
                 err_detail = 'ERROR: 请求失败！except：\n' + str(e) + '\n3s后重试(最多重试' + str(max_retry) + '次)'
@@ -298,12 +293,12 @@ class Anime:
         # 处理 cookie
         if not self._cookies:
             # 当实例中尚无 cookie, 则读取
-            self._cookies = self._session.cookies
+            self._cookies = self._session.cookies.get_dict()
         elif 'nologinuser' not in self._cookies.keys() and 'BAHAID' not in self._cookies.keys():
             # 处理游客cookie
-            if 'nologinuser' in self._session.cookies.keys():
+            if 'nologinuser' in self._session.cookies.get_dict().keys():
                 # self._cookies['nologinuser'] = self._session.cookies['nologinuser']
-                self._cookies = self._session.cookies
+                self._cookies = self._session.cookies.get_dict()
         else:  # 如果用户提供了 cookie, 则处理cookie刷新
             if 'set-cookie' in f.headers.keys():  # 发现server响应了set-cookie
                 if 'deleted' in f.headers.get('set-cookie'):
@@ -350,10 +345,10 @@ class Anime:
                     # 20220115 简化 cookie 刷新逻辑
                     err_print(self._sn, '收到新cookie', display=False)
 
-                    self._cookies.update(self._session.cookies)
+                    self._cookies.update(self._session.cookies.get_dict())
                     Config.renew_cookies(self._cookies, log=False)
 
-                    key_list_str = ', '.join(self._session.cookies.keys())
+                    key_list_str = ', '.join(self._session.cookies.get_dict().keys())
                     err_print(self._sn, f'用戶cookie刷新 {key_list_str} ', display=False)
 
                     self.__request('https://ani.gamer.com.tw/')
@@ -368,10 +363,7 @@ class Anime:
         return f
 
     def __request_json(self, req, no_cookies=False, show_fail=True, max_retry=3, addition_header=None, use_pyhttpx = False):
-        if use_pyhttpx:
-            return self.__request(req, no_cookies, show_fail, max_retry, addition_header, use_pyhttpx).json
-        else:
-            return self.__request(req, no_cookies, show_fail, max_retry, addition_header, use_pyhttpx).json()
+        return self.__request(req, no_cookies, show_fail, max_retry, addition_header, use_pyhttpx).json()
 
     def __get_m3u8_dict(self):
         # m3u8获取模块参考自 https://github.com/c0re100/BahamutAnimeDownloader

--- a/Config.py
+++ b/Config.py
@@ -8,6 +8,7 @@
 import os, json, re, sys, requests, time, random, codecs, chardet
 import sqlite3
 import socket
+from curl_cffi import requests as curl_requests
 from urllib.parse import quote
 from urllib.parse import urlencode
 
@@ -769,7 +770,28 @@ def renew_cookies(new_cookie, log=True):
         else:
             if log:
                 __color_print(0, '新cookie保存成功', no_sn=True, display=False)
-            break
+                break
+
+
+def bahamut_request(method, url, **kwargs):
+    # 巴哈站點請求統一走 curl-cffi，通過 TLS 指紋驗證
+    settings = read_settings()
+    if 'firefox' in settings['ua'].lower():
+        impersonate = 'firefox'
+    else:
+        impersonate = 'chrome124'
+    headers = dict(kwargs.pop('headers', None) or {})
+    if not any(k.lower() == 'user-agent' for k in headers):
+        headers['User-Agent'] = settings['ua']
+    kwargs['headers'] = headers
+    if settings.get('use_proxy') and settings.get('proxy'):
+        kwargs['proxies'] = {'https': settings['proxy'], 'http': settings['proxy']}
+    kwargs.setdefault('timeout', 10)
+    session = curl_requests.Session(impersonate=impersonate)
+    try:
+        return session.request(method, url, **kwargs)
+    except curl_requests.RequestsError as e:
+        raise requests.exceptions.RequestException(str(e)) from e
 
 
 def read_latest_version_on_github():

--- a/Danmu.py
+++ b/Danmu.py
@@ -1,5 +1,4 @@
 
-import requests
 import json
 import random
 import re
@@ -26,40 +25,35 @@ class Danmu():
         return result and result.group(0)
 
     def download(self, ban_words):
+        settings = Config.read_settings()
         h = {
-            'Content-Type':
-            'application/x-www-form-urlencoded;charset=utf-8',
-            'origin':
-            'https://ani.gamer.com.tw',
-            'authority':
-            'ani.gamer.com.tw',
-            'user-agent':
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36'
+            'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+            'origin': 'https://ani.gamer.com.tw',
+            'referer': f'https://ani.gamer.com.tw/animeVideo.php?sn={self._sn}',
+            'User-Agent': settings['ua'],
         }
         data = {'sn': str(self._sn)}
-        r = requests.post(
-            'https://ani.gamer.com.tw/ajax/danmuGet.php', data=data, headers=h)
+        r = Config.bahamut_request(
+            'POST', 'https://ani.gamer.com.tw/ajax/danmuGet.php',
+            data=data, headers=h, cookies=self._cookies)
 
         if r.status_code != 200:
             err_print(self._sn, '彈幕下載失敗', 'status_code=' + str(r.status_code), status=1)
             return
 
         h = {
-            'accept':
-            'application/json',
-            'origin':
-            'https://ani.gamer.com.tw',
-            'authority':
-            'ani.gamer.com.tw',
-            'user-agent':
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36',
+            'accept': 'application/json',
+            'origin': 'https://ani.gamer.com.tw',
+            'referer': f'https://ani.gamer.com.tw/animeVideo.php?sn={self._sn}',
+            'User-Agent': settings['ua'],
         }
-        ban_words_response = requests.get(
-            'https://ani.gamer.com.tw/ajax/keywordGet.php', headers=h, cookies=self._cookies)
+        ban_words_response = Config.bahamut_request(
+            'GET', 'https://ani.gamer.com.tw/ajax/keywordGet.php',
+            headers=h, cookies=self._cookies)
 
         if ban_words_response.status_code != 200:
             err_print(self._sn, '取得線上過濾彈幕失敗', 'status_code=' +
-                      str(r.status_code), status=1)
+                      str(ban_words_response.status_code), status=1)
         else:
             online_ban_words = json.loads(ban_words_response.text)
             for online_ban_word in online_ban_words:

--- a/aniGamerPlus.py
+++ b/aniGamerPlus.py
@@ -771,7 +771,7 @@ def __init_proxy():
 
 
 def do_request(url, headers, cookies, params=None):
-    return requests.get(url, headers=headers, cookies=cookies, params=params)
+    return Config.bahamut_request('GET', url, headers=headers, cookies=cookies, params=params)
 
 
 def parse_anime(soup, animes, headers, cookies):
@@ -790,14 +790,10 @@ def export_my_anime():
 
     url = "https://ani.gamer.com.tw/mygather.php"
     header = {
-        'accept':
-        'application/json',
-        'origin':
-        'https://ani.gamer.com.tw',
-        'authority':
-        'ani.gamer.com.tw',
-        'user-agent':
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36',
+        'accept': 'application/json',
+        'origin': 'https://ani.gamer.com.tw',
+        'referer': 'https://ani.gamer.com.tw/',
+        'User-Agent': settings['ua'],
     }
 
     cookies = Config.read_cookie()
@@ -810,7 +806,7 @@ def export_my_anime():
     while True:
         params = {'page': page, 'sort': 0}
         bahamygatherPage = do_request(url, headers=header, cookies=cookies, params=params)
-        if bahamygatherPage.status_code == requests.codes.ok:
+        if bahamygatherPage.status_code == 200:
             soup = BeautifulSoup(bahamygatherPage.text, 'html.parser')
             if not parse_anime(soup, animes, header, cookies):
                 break

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ pysocks==1.7.1
 lxml==4.9.1
 markupsafe<2.1.0
 greenlet==1.1.3
-pyhttpx
+curl-cffi>=0.7.0


### PR DESCRIPTION
## 摘要

7/16 起巴哈強化防爬蟲後，程式以 `pyhttpx` / `requests` 請求 `animeVideo.php` 會收到 **403 驗證頁**，導致 HTML 解析失敗（例如 `div.anime_name` 為 `None`）。

本 PR 將 HTTP 客戶端改為 **`curl-cffi`**，模擬真實瀏覽器 TLS 指紋以通過驗證。

相關議題：#311

## 修復內容

| 項目 | 內容 |
|------|------|
| Chrome UA | `impersonate="chrome124"` |
| Firefox UA | `impersonate="firefox"` |
| 依賴 | `requirements.txt`：`curl-cffi>=0.7.0` 取代 `pyhttpx` |

## 變更檔案

- `Anime.py`：統一使用 `curl_cffi.requests.Session`，移除 `pyhttpx` 雙 session 邏輯
- `requirements.txt`：`pyhttpx` → `curl-cffi>=0.7.0`


## 懶人包：
我有發佈在[這裡](https://github.com/BoringMan314/aniGamerPlus)
還有拿cookie 比較方便的[插件](https://chromewebstore.google.com/detail/bm-%E5%8B%95%E7%95%AB%E7%98%8B-%E7%8D%B2%E5%8F%96-cookie/mldicamgcdcfgdjibcojgfcnljooclen)
不放心的，還是等作者更新再用